### PR TITLE
set a default drip notice to avoid the blank messages

### DIFF
--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -46,8 +46,11 @@ protected $drip_message;
 */
 public function __construct(){
 	global $woo_sensei_content_drip;
-	// set a formated string
-	$this->message_format =  $woo_sensei_content_drip->settings->get_setting( 'scd_drip_message' ) ; 
+	
+	// set a formated  message shown to user when the content has not yet dripped
+	$defaultMessage = 'This lesson will only become available on [date].' ;
+	$settingsMessage =  $woo_sensei_content_drip->settings->get_setting( 'scd_drip_message' ) ; 
+	$this->message_format = empty( $settingsMessage ) ? $defaultMessage : $settingsMessage ; 
 
 	// hook int all post of type lesson to determin if they are 
 	add_filter('the_posts', array( $this, 'lessons_drip_filter' ), 1 );
@@ -281,9 +284,6 @@ public function is_dynamic_drip_active( $lesson_id ){
 * @return bool $dripped
 */
 public function get_drip_type_message( $lesson_id ){
-	
-	// setup the default message in case no data was paassed in
-	$message = 'Content hidden by the author of this lesson' ;
 
 	//check that the correct data has been passed
 	if( empty( $lesson_id) ){

--- a/includes/class-scd-ext-settings.php
+++ b/includes/class-scd-ext-settings.php
@@ -76,7 +76,7 @@ public function register_settings_fields( $sensei_settings_fields ){
 									'name' => __( 'Drip Message', 'sensei-content-drip' ),
 									'description' => __( 'The user will see this when the content is not yet available. The [date] shortcode will be replaced by the actual date' ),
 									'type' => 'textarea',
-									'default' => 'This lesson will become available on [date]',
+									'default' => 'This lesson will only become available on [date].',
 									'section' => 'sensei-content-drip-settings'
 									);
 


### PR DESCRIPTION
sets a default drip notice message of nothing was set in the settings. closes #30
