### PR TITLE
Don't show auto excerpt before lesson has dripped

### DIFF
--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -126,7 +126,8 @@ public function get_lesson_with_updated_content( $lesson ) {
 	$new_content = apply_filters( 'sensei_content_drip_lesson_message', $new_content );
 
 
-	// set the excerpt to be a trimmed down version of the full content if it is empty
+	// If a manual excerpt is not set, do not show an auto excerpt, and instead only
+	// display the sensei_content_drip_lesson_message.
 	if( empty( $lesson->post_excerpt )  ){
 
         $lesson->post_excerpt = $new_content;


### PR DESCRIPTION
If no manual excerpt has been set for a Lesson that has not dripped yet, we now show only the `sensei_content_drip_lesson_message` on both the Course and Lesson pages. 

Auto excerpts are ignored completely.

Will require some testing, but I believe this fixes #74.
