### PR TITLE
Check for translations before defaulting to strings in Settings

### DIFF
--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -47,10 +47,9 @@ class Scd_Ext_Access_Control {
 	 */
 	public function __construct() {
 		// set a formatted  message shown to user when the content has not yet dripped
-    	$default_message = 'This lesson will become available on [date].';
-    	$settings_field =  'scd_drip_message';
-    	$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
-
+		$default_message = 'This lesson will become available on [date].';
+		$settings_field =  'scd_drip_message';
+		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 	}// end __construct()
 
 	/**

--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -47,9 +47,10 @@ class Scd_Ext_Access_Control {
 	 */
 	public function __construct() {
 		// set a formatted  message shown to user when the content has not yet dripped
-		$default_message = 'This lesson will become available on [date].';
-		$settings_field =  'scd_drip_message';
-		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
+		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation(
+			'This lesson will become available on [date].',
+			'scd_drip_message'
+		);
 	}// end __construct()
 
 	/**

--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -42,16 +42,16 @@ class Scd_Ext_Access_Control {
 	 */
 	protected $drip_message;
 
-
 	/**
 	 * constructor function
 	 */
 	public function __construct() {
-		// Set a formatted  message shown to user when the content has not yet dripped
-		$defaultMessage       = __( 'This lesson will become available on [date].', 'sensei-content-drip' );
-		$settingsMessage      = Sensei_Content_Drip()->settings->get_setting( 'scd_drip_message' );
-		$this->message_format = empty( $settingsMessage ) ? $defaultMessage : $settingsMessage;
-	}
+		// set a formatted  message shown to user when the content has not yet dripped
+    	$default_message = 'This lesson will become available on [date].';
+    	$settings_field =  'scd_drip_message';
+    	$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
+
+	}// end __construct()
 
 	/**
 	 * Check if  the lesson can be made available to the the user at this point

--- a/includes/class-scd-ext-drip-email.php
+++ b/includes/class-scd-ext-drip-email.php
@@ -316,19 +316,19 @@ class Scd_Ext_Drip_Email {
 		 * @param string $email_greeting Defaults to "Good Day $first_name"
 		 * @param int $user_id
 		 */
-		$body_default_message = 'The following lessons will become available today:';
-		$body_settings_field =  'scd_email_body_notice_html';
-		$email_body_text = Sensei_Content_Drip()->utils->check_for_translation( $body_default_message, $body_settings_field );
+		$email_body_text = Sensei_Content_Drip()->utils->check_for_translation(
+			'The following lessons will become available today:',
+			'scd_email_body_notice_html'
+		);
 
 		$email_greeting     = sprintf( '<p>%s</p>', esc_html( apply_filters( 'scd_email_greeting', __( 'Good Day', 'sensei-content-drip' ) . ' ' . $first_name ) ) );
 		$email_body_notice  = '<p>' . esc_html( $email_body_text ) . '</p>';
 		$email_body_lessons = '';
 
 		// Get the footer from the settings and replace the shortcode [home_url] with the actual site url
-		// get the footer from the settings and replace the shortcode [home_url] with the actual site url
-		$footer_default_message = 'Visit the online course today to start taking the lessons: [home_url]';
-		$footer_settings_field =  'scd_email_footer_html';
-		$email_footer_text = Sensei_Content_Drip()->utils->check_for_translation( $footer_default_message, $footer_settings_field );
+		$email_footer_text = Sensei_Content_Drip()->utils->check_for_translation(
+			'Visit the online course today to start taking the lessons: [home_url]',
+			'scd_email_footer_html' );
 
 		$email_footer = '<p>' . str_ireplace( '[home_url]'  , '<a href="' . esc_attr( home_url() ) . '" >' . esc_html( home_url() ) . '</a>' , esc_html( $email_footer_text ) ) . '</p>';
 

--- a/includes/class-scd-ext-drip-email.php
+++ b/includes/class-scd-ext-drip-email.php
@@ -307,21 +307,7 @@ class Scd_Ext_Drip_Email {
 		$wrap_header = $email_wrappers['wrap_header'];
 		$wrap_footer = $email_wrappers['wrap_footer'];
 
-		// Get the settings values
-		$settings['email_body_notice'] = Sensei_Content_Drip()->settings->get_setting( 'scd_email_body_notice_html' );
-		$settings['email_footer']      = Sensei_Content_Drip()->settings->get_setting( 'scd_email_footer_html' );
-
-		// Check for empty settings and setup the defaults
-		if ( empty( $settings['email_body_notice'] ) ) {
-			$settings['email_body_notice'] = __( 'The following lessons will become available today:' , 'sensei-content-drip' );
-		}
-
-		if ( empty( $settings['email_footer'] ) ) {
-			$settings['email_footer'] = __(  'Visit the online course today to start taking the lessons: [home_url]' , 'sensei-content-drip' );
-		}
-
 		// Setup the  the message content
-
 		/**
 		 * Email user greeting filter.
 		 *
@@ -330,12 +316,21 @@ class Scd_Ext_Drip_Email {
 		 * @param string $email_greeting Defaults to "Good Day $first_name"
 		 * @param int $user_id
 		 */
+		$body_default_message = 'The following lessons will become available today:';
+		$body_settings_field =  'scd_email_body_notice_html';
+		$email_body_text = Sensei_Content_Drip()->utils->check_for_translation( $body_default_message, $body_settings_field );
+
 		$email_greeting     = sprintf( '<p>%s</p>', esc_html( apply_filters( 'scd_email_greeting', __( 'Good Day', 'sensei-content-drip' ) . ' ' . $first_name ) ) );
-		$email_body_notice  = '<p>' . esc_html( $settings['email_body_notice'] ) . '</p>';
+		$email_body_notice  = '<p>' . esc_html( $email_body_text ) . '</p>';
 		$email_body_lessons = '';
 
 		// Get the footer from the settings and replace the shortcode [home_url] with the actual site url
-		$email_footer = '<p>' . str_ireplace( '[home_url]'  , '<a href="' . esc_attr( home_url() ) . '" >' . esc_html( home_url() ) . '</a>' , esc_html( $settings['email_footer'] ) ) . '</p>';
+		// get the footer from the settings and replace the shortcode [home_url] with the actual site url
+		$footer_default_message = 'Visit the online course today to start taking the lessons: [home_url]';
+		$footer_settings_field =  'scd_email_footer_html';
+		$email_footer_text = Sensei_Content_Drip()->utils->check_for_translation( $footer_default_message, $footer_settings_field );
+
+		$email_footer = '<p>' . str_ireplace( '[home_url]'  , '<a href="' . esc_attr( home_url() ) . '" >' . esc_html( home_url() ) . '</a>' , esc_html( $email_footer_text ) ) . '</p>';
 
 		// Loop through each lesson to get its title and relative url
 		$email_body_lessons .= '<p><ul>';

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -48,9 +48,9 @@ class Scd_Ext_Lesson_Frontend {
 	 */
 	public function __construct() {
 		// Set a formatted  message shown to user when the content has not yet dripped
-		$default_message       = esc_html__( 'This lesson will become available on [date].', 'sensei-content-drip' );
-		$settings_message      = Sensei_Content_Drip()->settings->get_setting( 'scd_drip_message' );
-		$this->message_format = empty( $settings_message ) ? $default_message : $settings_message;
+		$default_message = 'This lesson will become available on [date].';
+		$settings_field =  'scd_drip_message';
+		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
 		// Hook int all post of type lesson to determine if they should be
 		add_filter('the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -51,7 +51,7 @@ class Scd_Ext_Quiz_Frontend {
 		// Set a formatted  message shown to user when the content has not yet dripped
 		$default_message = 'This quiz will become available on [date].';
 		$settings_field=  'scd_drip_quiz_message';
-    	$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
+		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -49,9 +49,9 @@ class Scd_Ext_Quiz_Frontend {
 	 */
 	public function __construct() {
 		// Set a formatted  message shown to user when the content has not yet dripped
-		$default_message      = esc_html__( 'This quiz will become available on [date].', 'sensei-content-drip' );
-		$settings_message     = Sensei_Content_Drip()->settings->get_setting( 'scd_drip_quiz_message' );
-		$this->message_format = empty( $settings_message ) ? $default_message : $settings_message;
+		$default_message = 'This quiz will become available on [date].';
+		$settings_field=  'scd_drip_quiz_message';
+    	$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -49,10 +49,10 @@ class Scd_Ext_Quiz_Frontend {
 	 */
 	public function __construct() {
 		// Set a formatted  message shown to user when the content has not yet dripped
-		$default_message = 'This quiz will become available on [date].';
-		$settings_field=  'scd_drip_quiz_message';
-		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
-
+		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation(
+			'This quiz will become available on [date].',
+			'scd_drip_quiz_message'
+		);
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );
 		// Show SCD Message if Quiz lesson is restricted

--- a/includes/class-scd-ext-utilities.php
+++ b/includes/class-scd-ext-utilities.php
@@ -114,41 +114,27 @@ class Scd_Ext_Utils {
 	}
 
     /**
-     *  check_for_translation() function
-     *
      *  Handles which message to show users
      *  when the message is both set in a
      *  translation, as well as under Sensei ->
-     *  Settings -> Content Drip.
+     *  Settings -> Content Drip. Translation takes precedence, then setting then default message
      *
      *	@param str $default_message
      *  @param str $settings_field
-     *  @return str $message
+     *  @return str
+	 *  @from 1.0.7
      */
-    public function check_for_translation($default_message, $settings_field) {
+    public function check_for_translation( $default_message, $settings_field ) {
 
-        $possible_translation = __($default_message, 'sensei-content-drip' ) ;
-        $settings_message =  Sensei_Content_Drip()->settings->get_setting( $settings_field ) ;
-
-        // If the $default_message has been translated, return that.
-        if ($possible_translation != $default_message ) {
-
-            $message = $possible_translation;
-
-        // If not, return the string set under Sensei -> Settings -> Content Drip.
-        } elseif ( !empty($settings_message) ) {
-
-            $message = $settings_message;
-
-        // If that is not set either, return the default English string.
-        } else {
-
-            $message = $default_message;
-        }
-
-        return $message;
-
-
+		$possible_translation = __( $default_message, 'sensei-content-drip' ) ;
+		// Return the translation if present
+		if ($possible_translation != $default_message ) {
+			return $possible_translation;
+		}
+		// If not, check if "Sensei -> Settings -> Content Drip" is set and return that
+		// If that is not set either, return the default English string.
+		$settings_message =  Sensei_Content_Drip()->settings->get_setting( $settings_field );
+		return ( empty( $settings_message ) ) ? $default_message : $settings_message;
     } // end check_for_translation()
 
 } // end class Sensei_Scd_Extension_Utils

--- a/includes/class-scd-ext-utilities.php
+++ b/includes/class-scd-ext-utilities.php
@@ -109,6 +109,47 @@ class Scd_Ext_Utils {
 			$drip_date = DateTime::createFromFormat( 'U', $lesson_set_date );
 		}
 
+
 		return $drip_date;
 	}
-}
+
+    /**
+     *  check_for_translation() function
+     *
+     *  Handles which message to show users
+     *  when the message is both set in a
+     *  translation, as well as under Sensei ->
+     *  Settings -> Content Drip.
+     *
+     *	@param str $default_message
+     *  @param str $settings_field
+     *  @return str $message
+     */
+    public function check_for_translation($default_message, $settings_field) {
+
+        $possible_translation = __($default_message, 'sensei-content-drip' ) ;
+        $settings_message =  Sensei_Content_Drip()->settings->get_setting( $settings_field ) ;
+
+        // If the $default_message has been translated, return that.
+        if ($possible_translation != $default_message ) {
+
+            $message = $possible_translation;
+
+        // If not, return the string set under Sensei -> Settings -> Content Drip.
+        } elseif ( !empty($settings_message) ) {
+
+            $message = $settings_message;
+
+        // If that is not set either, return the default English string.
+        } else {
+
+            $message = $default_message;
+        }
+
+        return $message;
+
+
+    } // end check_for_translation()
+
+} // end class Sensei_Scd_Extension_Utils
+


### PR DESCRIPTION
Fixes #75. For the 4 strings in Sensei -> Settings -> Content Drip, we now check:

1) String has an active translation? Use it.

2) No active translation, but has a value set under Sensei -> Settings -> Content Drip? Use it.

3) No active translation, or value set in Settings? Use default English string.

Created a `utils->check_for_translation()` function to store this logic.

Preliminary testing shows the fix works in all the above use cases, but additional testing / cleanup will be required.
