### PR TITLE
Fix time formatting by storing dates as unix timestamps in DB.

### DIFF
--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -218,7 +218,7 @@ class Scd_Ext_Access_Control {
 				return $drip_date;
 			}
 
-			$drip_date = new DateTime( $lesson_set_date );
+			$drip_date = DateTime::createFromFormat( 'U', $lesson_set_date );
 
 		} elseif ( 'dynamic' === $drip_type ) {
 			// Get the drip details array data

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -113,7 +113,7 @@ class Scd_Ext_Lesson_Admin {
 		if ( 'none' === $drip_type ) {
 			echo 'Immediately';
 		} else if ( 'absolute' === $drip_type ) {
-			$lesson_set_date = get_post_meta( $lesson_id ,'_sensei_content_drip_details_date', true  );
+			$lesson_set_date = date_i18n( get_option( 'date_format' ), $lesson_set_date );
 			echo 'On '. $lesson_set_date;
 		} else if ( 'dynamic' === $drip_type ) {
 			$unit_type   = get_post_meta( $lesson_id , '_sensei_content_drip_details_date_unit_type', true );
@@ -174,7 +174,7 @@ class Scd_Ext_Lesson_Admin {
 			$dymaic_hidden_class   = 'hidden';
 
 			// Get the absolute date stored field value
-			$absolute_date_value =  $lesson_drip_data['_sensei_content_drip_details_date'];
+			$absolute_date_value = date_i18n( get_option( 'date_format' ), $lesson_drip_data['_sensei_content_drip_details_date'] );
 		} else if ( 'dynamic' === $selected_drip_type ) {
 			$absolute_hidden_class = 'hidden';
 			$dymaic_hidden_class   = '';
@@ -308,6 +308,8 @@ class Scd_Ext_Lesson_Admin {
 
 				return $post_id;
 			}
+
+			$date_string = DateTime::createFromFormat( get_option( 'date_format' ), $date_string )->getTimestamp();
 
 			// Set the meta data to be saves later
 			// Set the mets data to ready to pass it onto saving

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -200,8 +200,9 @@ class Scd_Ext_Lesson_Frontend {
 		$absolute_drip_type_message = '';
 
 		// Get this lessons drip data
-		$lesson_drip_date = new DateTime( get_post_meta( $lesson_id , '_sensei_content_drip_details_date' , true ) );
-		$formatted_date   = date_i18n( get_option( 'date_format' ), $lesson_drip_date->getTimestamp() );
+
+		$lesson_drip_timestamp = get_post_meta( $lesson_id , '_sensei_content_drip_details_date' , true );
+		$formatted_date = date_i18n( get_option( 'date_format' ), $lesson_drip_timestamp );
 
 		// Replace the shortcode in the class message_format property set in the constructor
 		if ( strpos( $this->message_format , '[date]' ) ) {

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -169,7 +169,8 @@ class Scd_Ext_Quiz_Frontend {
 		$absolute_drip_type_message = '';
 
 		// Get this quizs drip data
-		$quiz_drip_date = new DateTime( get_post_meta( $quiz_id , '_sensei_content_drip_details_date' , true ) );
+
+		$quiz_drip_date = DateTime::createFromFormat( 'U', get_post_meta( $quiz_id , '_sensei_content_drip_details_date' , true ) );
 		$formatted_date = $quiz_drip_date->format( Sensei_Content_Drip()->get_date_format_string() );
 
 		// Replace the shortcode in the class message_format property set in the constructor


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-content-drip/issues/103.
