### PR TITLE
Fix time formatting by storing dates as unix timestamps in DB.

### DIFF
--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -212,14 +212,7 @@ class Scd_Ext_Access_Control {
 		}
 
 		if ( 'absolute' === $drip_type ) {
-			$lesson_set_date = get_post_meta( $lesson_id ,'_sensei_content_drip_details_date', true  );
-
-			if ( empty( $lesson_set_date ) ) {
-				return $drip_date;
-			}
-
-			$drip_date = new DateTime( $lesson_set_date );
-
+			$drip_date = Scd_Ext_Utils::date_from_datestring_or_timestamp( $lesson_id );
 		} elseif ( 'dynamic' === $drip_type ) {
 			// Get the drip details array data
 			$unit_type   = get_post_meta( $lesson_id , '_sensei_content_drip_details_date_unit_type', true );

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -93,6 +93,23 @@ class Scd_Ext_Lesson_Admin {
 	}
 
 	/**
+	 * Attempts to retrieve the date in localized format (if using new format), otherwise return plain format
+	 *
+	 * @param  string $lesson_id
+	 * @return DateTime|string
+	 */
+	private function date_or_datestring_from_lesson( $lesson_id ) {
+		$lesson_set_date = get_post_meta( $lesson_id, '_sensei_content_drip_details_date', true );
+
+		if ( ctype_digit( $lesson_set_date ) ) {
+			// we are using new data in db, format accordingly
+			$lesson_set_date = date_i18n( get_option( 'date_format' ), $lesson_set_date );
+		}
+
+		return $lesson_set_date;
+	}
+
+	/**
 	 * Add data for our drip schedule custom column
 	 *
 	 * @since  1.0.0
@@ -113,7 +130,7 @@ class Scd_Ext_Lesson_Admin {
 		if ( 'none' === $drip_type ) {
 			echo 'Immediately';
 		} else if ( 'absolute' === $drip_type ) {
-			$lesson_set_date = get_post_meta( $lesson_id ,'_sensei_content_drip_details_date', true  );
+			$lesson_set_date = $this->date_or_datestring_from_lesson( $lesson_id );
 			echo 'On '. $lesson_set_date;
 		} else if ( 'dynamic' === $drip_type ) {
 			$unit_type   = get_post_meta( $lesson_id , '_sensei_content_drip_details_date_unit_type', true );
@@ -174,7 +191,7 @@ class Scd_Ext_Lesson_Admin {
 			$dymaic_hidden_class   = 'hidden';
 
 			// Get the absolute date stored field value
-			$absolute_date_value =  $lesson_drip_data['_sensei_content_drip_details_date'];
+			$absolute_date_value = $this->date_or_datestring_from_lesson( $post->ID );
 		} else if ( 'dynamic' === $selected_drip_type ) {
 			$absolute_hidden_class = 'hidden';
 			$dymaic_hidden_class   = '';
@@ -308,6 +325,8 @@ class Scd_Ext_Lesson_Admin {
 
 				return $post_id;
 			}
+
+			$date_string = DateTime::createFromFormat( get_option( 'date_format' ), $date_string )->getTimestamp();
 
 			// Set the meta data to be saves later
 			// Set the mets data to ready to pass it onto saving

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -200,8 +200,10 @@ class Scd_Ext_Lesson_Frontend {
 		$absolute_drip_type_message = '';
 
 		// Get this lessons drip data
-		$lesson_drip_date = new DateTime( get_post_meta( $lesson_id , '_sensei_content_drip_details_date' , true ) );
-		$formatted_date   = date_i18n( get_option( 'date_format' ), $lesson_drip_date->getTimestamp() );
+		$lesson_drip_date = Scd_Ext_Utils::date_from_datestring_or_timestamp( $lesson_id );
+		$lesson_drip_timestamp = $lesson_drip_date->getTimestamp();
+
+		$formatted_date = date_i18n( get_option( 'date_format' ), $lesson_drip_timestamp );
 
 		// Replace the shortcode in the class message_format property set in the constructor
 		if ( strpos( $this->message_format , '[date]' ) ) {

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -169,7 +169,8 @@ class Scd_Ext_Quiz_Frontend {
 		$absolute_drip_type_message = '';
 
 		// Get this quizs drip data
-		$quiz_drip_date = new DateTime( get_post_meta( $quiz_id , '_sensei_content_drip_details_date' , true ) );
+		$quiz_drip_date = Scd_Ext_Utils::date_from_datestring_or_timestamp( $quiz_id );
+
 		$formatted_date = $quiz_drip_date->format( Sensei_Content_Drip()->get_date_format_string() );
 
 		// Replace the shortcode in the class message_format property set in the constructor

--- a/includes/class-scd-ext-utilities.php
+++ b/includes/class-scd-ext-utilities.php
@@ -92,4 +92,23 @@ class Scd_Ext_Utils {
 
 		return $course_users;
 	}
+
+	/**
+	 * Return a DateTime object for the given lesson ID (bwc support)
+	 *
+	 * @param  string $lesson_id
+	 * @return DateTime|bool
+	 */
+	public static function date_from_datestring_or_timestamp( $lesson_id ) {
+		$lesson_set_date = get_post_meta( $lesson_id, '_sensei_content_drip_details_date', true );
+
+		if ( ! ctype_digit( $lesson_set_date ) ) {
+			// backwards compatibility for data that's still using the old format
+			$drip_date = new DateTime( $lesson_set_date );
+		} else {
+			$drip_date = DateTime::createFromFormat( 'U', $lesson_set_date );
+		}
+
+		return $drip_date;
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-content-drip/issues/103.