### PR TITLE
Don't show quiz/media content if lesson hasn't dripped

### DIFF
--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -64,7 +64,7 @@ class Scd_Ext_Lesson_Frontend {
 	 * @return array $lessons
 	 * @uses   the_posts()
 	 */
-	public function lesson_content_drip_filter( $lessons, WP_Query $query = null ) {
+	public function lesson_content_drip_filter( $lessons ) {
 		// This should only apply to the front end on single course and lesson pages
 		if ( is_admin() || empty( $lessons ) ) {
 			return $lessons;
@@ -84,8 +84,8 @@ class Scd_Ext_Lesson_Frontend {
 				// Remove hooked
 				global $wp_query;
 
-				if ( $wp_query->is_main_query() && $query === $wp_query && 'lesson' === $wp_query->query_vars['post_type'] ) {
-					$current_lesson = array_shift( $wp_query->posts );
+				if ( $wp_query->is_main_query() && count( $wp_query->posts ) > 0 && 'lesson' === $wp_query->query_vars['post_type'] ) {
+					$current_lesson = $wp_query->posts[0];
 
 					if ( isset( $current_lesson->ID ) && $current_lesson->ID === $lesson->ID ) {
 						$this->remove_single_lesson_hooks();

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -156,6 +156,9 @@ class Scd_Ext_Lesson_Frontend {
 
 		// Hide the lesson quiz notice
 		remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
+		
+		// Hide lesson meta (e.g. Media from Sensei-Media-Items.)
+		remove_all_actions( 'sensei_lesson_single_meta' );
 	}
 
 

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -57,8 +57,6 @@ class Scd_Ext_Quiz_Frontend {
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );
 		// Show SCD Message if Quiz lesson is restricted
 		add_action( 'sensei_single_quiz_content_inside_before', array( $this, 'the_user_status_message' ), 40 );
-		// User Should not be able to view restricted quiz Questions
-		add_filter( 'sensei_can_user_view_lesson', array( $this, 'can_user_access_quiz_for_lesson' ), 20, 2 );
 	}
 
 	/**
@@ -82,6 +80,8 @@ class Scd_Ext_Quiz_Frontend {
 			if ( Sensei_Content_Drip()->access_control->is_lesson_access_blocked( $lesson_id ) ) {
 				// Change the quiz content accordingly
 				$quizzes[ $index ] = $this->get_quiz_with_updated_content( $quiz );
+				// User Should not be able to view restricted quiz Questions
+				add_filter( 'sensei_can_user_view_lesson', array( $this, 'can_user_access_quiz_for_lesson' ), 20, 2 );
 			}
 		}
 


### PR DESCRIPTION
Don't show quiz content if lesson hasn't dripped
When visiting a quiz page:

- Don't show quiz content if it is part of a lesson that hasn't dripped yet.
- Display SCD Message if this Quiz is part of a lesson that has't
  dripped yet.

NB: There was a hook that changed post content of quizzes but
those were never used in sensei templates.

closes #99

Steps to test:

- Create a course with two lessons, set the second one to drip.
- Add a quiz to the second lesson
- Try to access the quiz page. You see only the SCD notice and no quiz questions
- ON the lesson page, you do not see a button that gets you to the quiz