### PR TITLE
Add the option to disable Email notifications in Settings.

### DIFF
--- a/includes/class-scd-ext-drip-email.php
+++ b/includes/class-scd-ext-drip-email.php
@@ -32,8 +32,12 @@ class Scd_Ext_Drip_Email {
 	 * Construction function that hooks into the WordPress workflow
 	 */
 	public function __construct() {
-		// Add email sending action to the cron job
-		add_action ( 'woo_scd_daily_cron_hook' , array( $this, 'daily_drip_lesson_email_run' ) );
+		$disable_email = Sensei_Content_Drip()->settings->get_setting( 'scd_disable_email_notifications' );
+
+		if ( ! $disable_email ) {
+			// Add email sending action to the cron job
+			add_action ( 'woo_scd_daily_cron_hook' , array( $this, 'daily_drip_lesson_email_run' ) );
+		}
 	}
 
 	/**

--- a/includes/class-scd-ext-settings.php
+++ b/includes/class-scd-ext-settings.php
@@ -91,6 +91,14 @@ class Scd_Ext_Settings {
 		);
 
 		// Email related settings
+		$sensei_settings_fields['scd_disable_email_notifications'] = array(
+			'name'        => __( 'Email Notifications', 'sensei-content-drip' ),
+			'description' => __( 'Disable Email Notifications', 'sensei-content-drip' ),
+			'type'        => 'checkbox',
+			'default'     => 'false',
+			'section'     => 'sensei-content-drip-settings',
+		);
+
 		$sensei_settings_fields['scd_email_body_notice_html'] = array(
 			'name'        => __( 'Email Before Lessons', 'sensei-content-drip' ),
 			'description' => __( 'The text before the list of lessons dripping today.', 'sensei-content-drip' ),


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-content-drip/issues/60.

<img width="581" alt="screen shot 2016-11-10 at 20 18 09" src="https://cloud.githubusercontent.com/assets/1620929/20190713/d70944dc-a782-11e6-9fa2-5c030118abcb.png">