### PR TITLE
Add the ability in lessons to send test emails

### DIFF
--- a/assets/js/admin-lesson.js
+++ b/assets/js/admin-lesson.js
@@ -8,7 +8,8 @@
 
 		el: '#content-drip-lesson .inside',
 		events: {
-			'change .sdc-lesson-drip-type': 'dripTypeChange'
+			'change .sdc-lesson-drip-type': 'dripTypeChange',
+			'click .send_test_email': 'sendTestEmail'
 		},
 
 		/**
@@ -88,6 +89,23 @@
 
 			this.dripType = e.target.value;
 			this.render();
+		},
+
+		/**
+		 * sendTestEmail, this function implements the logic for sending test emails through AJAX
+		 */
+		sendTestEmail: function( e ) {
+			var data = {
+				'action': 'send_test_email',
+				'nonce': scdManualDrip.nonce,
+				'userId': jQuery('#user-id').val(),
+				'lessonId': jQuery('#post_ID').val(),
+			};
+
+			jQuery.post( ajaxurl, data, function( response ) {
+				scdManualDrip.nonce = response.data.newNonce;
+				alert( response.data.notice );
+			});
 		},
 	} );
 

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -223,6 +223,7 @@ class Scd_Ext_Lesson_Admin {
 				</div>
 			<?php endif; ?>
 		</div><!-- end dripTypeOptions -->
+		<a title="Send Test Email" href="#send-test-email" class="send_test_email button button-primary button-highlighted">Send Test Email</a>
 		</p>
 		<?php
 	}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-content-drip/issues/86.

The PR adds the following button to lessons Edit view:
<img width="734" alt="screen shot 2016-11-20 at 17 17 19" src="https://cloud.githubusercontent.com/assets/1620929/20464292/3e8f2be8-af45-11e6-8f81-583139f32f25.png">

After clicking the button, the user gets the following alert:
<img width="472" alt="screen shot 2016-11-20 at 17 17 24" src="https://cloud.githubusercontent.com/assets/1620929/20464295/44917046-af45-11e6-87e9-8fb70121bf94.png">

And the following e-mail:
<img width="800" alt="screen shot 2016-11-20 at 17 16 43" src="https://cloud.githubusercontent.com/assets/1620929/20464301/5da61d7a-af45-11e6-9a04-2e2869037a10.png">