### PR TITLE
Fix access to dripped lessons for users not taking the course

### DIFF
--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -67,10 +67,12 @@ class Scd_Ext_Access_Control {
 
 		// Return drip not active for the following conditions.
 		if ( is_super_admin() || empty( $lesson_id ) || 'lesson' !== get_post_type( $lesson_id )
-		     || Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() )
-		     || ! Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() ) ) {
+		     || Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() ) ) {
 			return false;
 		}
+
+		// Check if user has started the course.
+		$user_started_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
 
 		// get the lessons drip data if any
 		$drip_type = get_post_meta( $lesson_id , '_sensei_content_drip_type', true );
@@ -81,7 +83,12 @@ class Scd_Ext_Access_Control {
 		} elseif ( 'absolute' === $drip_type  ) {
 			$content_access_blocked = $this->is_absolute_drip_type_content_blocked( $lesson_id  );
 		} elseif ( 'dynamic' === $drip_type ) {
-			$content_access_blocked = $this->is_dynamic_drip_type_content_blocked( $lesson_id  );
+			// If the user is not taking the course, block it.
+			if ( $user_started_course ) {
+				$content_access_blocked = $this->is_dynamic_drip_type_content_blocked( $lesson_id  );
+			} else {
+				$content_access_blocked = true;
+			}
 		}
 
 		/**

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -52,9 +52,6 @@ class Scd_Ext_Lesson_Frontend {
 		$settings_field =  'scd_drip_message';
 		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
-		// TODO: add a setting for this.
-		$this->message_without_date = __( 'This lesson is not available before starting the course.', 'sensei-content-drip' );
-
 		// Hook int all post of type lesson to determine if they should be
 		add_filter('the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );
 	}
@@ -236,7 +233,7 @@ class Scd_Ext_Lesson_Frontend {
 		$lesson_available_date     = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id , $user_id );
 
 		if ( ! $lesson_available_date ) {
-			return esc_html( $this->message_without_date );
+			return '';
 		}
 
 		$formatted_date            = date_i18n( get_option( 'date_format' ), $lesson_available_date->getTimestamp() );

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -52,6 +52,9 @@ class Scd_Ext_Lesson_Frontend {
 		$settings_field =  'scd_drip_message';
 		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
+		// TODO: add a setting for this.
+		$this->message_without_date = __( 'This lesson is not available before starting the course.', 'sensei-content-drip' );
+
 		// Hook int all post of type lesson to determine if they should be
 		add_filter('the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );
 	}
@@ -156,7 +159,7 @@ class Scd_Ext_Lesson_Frontend {
 
 		// Hide the lesson quiz notice
 		remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
-		
+
 		// Hide lesson meta (e.g. Media from Sensei-Media-Items.)
 		remove_all_actions( 'sensei_lesson_single_meta' );
 	}
@@ -231,6 +234,11 @@ class Scd_Ext_Lesson_Frontend {
 		$user_id                   = $current_user->ID;
 		$dynamic_drip_type_message = '';
 		$lesson_available_date     = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id , $user_id );
+
+		if ( ! $lesson_available_date ) {
+			return esc_html( $this->message_without_date );
+		}
+
 		$formatted_date            = date_i18n( get_option( 'date_format' ), $lesson_available_date->getTimestamp() );
 
 		// Replace string content in the class message_format property set in the constructor

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -52,11 +52,8 @@ class Scd_Ext_Lesson_Frontend {
 		$settings_field =  'scd_drip_message';
 		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
-		// Set a message to show to users when the content has not yet dripped and we cannot compute a date for when it will drip.
-		$this->message_without_date = Sensei_Content_Drip()->utils->check_for_translation(
-			'This lesson is not available before starting the course.',
-			'scd_drip_message_without_date'
-		);
+		// TODO: add a setting for this.
+		$this->message_without_date = __( 'This lesson is not available before starting the course.', 'sensei-content-drip' );
 
 		// Hook int all post of type lesson to determine if they should be
 		add_filter('the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -52,8 +52,11 @@ class Scd_Ext_Lesson_Frontend {
 		$settings_field =  'scd_drip_message';
 		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
 
-		// TODO: add a setting for this.
-		$this->message_without_date = __( 'This lesson is not available before starting the course.', 'sensei-content-drip' );
+		// Set a message to show to users when the content has not yet dripped and we cannot compute a date for when it will drip.
+		$this->message_without_date = Sensei_Content_Drip()->utils->check_for_translation(
+			'This lesson is not available before starting the course.',
+			'scd_drip_message_without_date'
+		);
 
 		// Hook int all post of type lesson to determine if they should be
 		add_filter('the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -54,8 +54,11 @@ class Scd_Ext_Quiz_Frontend {
 			'scd_drip_quiz_message'
 		);
 
-		// TODO: add a setting for this.
-		$this->message_without_date = __( 'This quiz is not available before starting the course.', 'sensei-content-drip' );
+		// Set a message to show to users when the content has not yet dripped and we cannot compute a date for when it will drip.
+		$this->message_without_date = Sensei_Content_Drip()->utils->check_for_translation(
+			'This quiz is not available before starting the course.',
+			'scd_drip_quiz_message_without_date'
+		);
 
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -116,9 +116,11 @@ class Scd_Ext_Quiz_Frontend {
 			return;
 		}
 
-		$lesson_id =  Sensei()->quiz->get_lesson_id( $quiz_id );
+		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
+		$user_id   = get_current_user_id();
 
-		if ( Sensei_Content_Drip()->access_control->is_lesson_access_blocked( $lesson_id ) ) {
+		if ( Sensei_Content_Drip()->access_control->is_lesson_access_blocked( $lesson_id ) &&
+			! Sensei_Content_Drip()->access_control->sensei_should_block_lesson( $lesson_id, $user_id ) ) {
 			$drip_message_body = $this->get_drip_type_message( $quiz_id );
 			if ( empty( $drip_message_body ) ) {
 				return;

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -54,11 +54,8 @@ class Scd_Ext_Quiz_Frontend {
 			'scd_drip_quiz_message'
 		);
 
-		// Set a message to show to users when the content has not yet dripped and we cannot compute a date for when it will drip.
-		$this->message_without_date = Sensei_Content_Drip()->utils->check_for_translation(
-			'This quiz is not available before starting the course.',
-			'scd_drip_quiz_message_without_date'
-		);
+		// TODO: add a setting for this.
+		$this->message_without_date = __( 'This quiz is not available before starting the course.', 'sensei-content-drip' );
 
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -53,10 +53,6 @@ class Scd_Ext_Quiz_Frontend {
 			'This quiz will become available on [date].',
 			'scd_drip_quiz_message'
 		);
-
-		// TODO: add a setting for this.
-		$this->message_without_date = __( 'This quiz is not available before starting the course.', 'sensei-content-drip' );
-
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );
 		// Show SCD Message if Quiz lesson is restricted
@@ -251,7 +247,7 @@ class Scd_Ext_Quiz_Frontend {
 		$quiz_available_date       = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id , $user_id );
 
 		if ( ! $quiz_available_date ) {
-			return esc_html( $this->message_without_date );
+			return '';
 		}
 
 		$formatted_date            = date_i18n( Sensei_Content_Drip()->get_date_format_string( ), $quiz_available_date->getTimestamp() );

--- a/includes/class-scd-ext-quiz-frontend.php
+++ b/includes/class-scd-ext-quiz-frontend.php
@@ -53,6 +53,10 @@ class Scd_Ext_Quiz_Frontend {
 			'This quiz will become available on [date].',
 			'scd_drip_quiz_message'
 		);
+
+		// TODO: add a setting for this.
+		$this->message_without_date = __( 'This quiz is not available before starting the course.', 'sensei-content-drip' );
+
 		// Hook int all post of type quiz to determine if they should be
 		add_filter( 'the_posts', array( $this, 'quiz_content_drip_filter' ), 1 );
 		// Show SCD Message if Quiz lesson is restricted
@@ -245,6 +249,11 @@ class Scd_Ext_Quiz_Frontend {
 		$user_id                   = $current_user->ID;
 		$dynamic_drip_type_message = '';
 		$quiz_available_date       = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id , $user_id );
+
+		if ( ! $quiz_available_date ) {
+			return esc_html( $this->message_without_date );
+		}
+
 		$formatted_date            = date_i18n( Sensei_Content_Drip()->get_date_format_string( ), $quiz_available_date->getTimestamp() );
 
 		// Replace string content in the class message_format property set in the constructor

--- a/includes/class-scd-ext-settings.php
+++ b/includes/class-scd-ext-settings.php
@@ -82,27 +82,11 @@ class Scd_Ext_Settings {
 			'section'     => 'sensei-content-drip-settings',
 		);
 
-		$sensei_settings_fields['scd_drip_message_without_date'] = array(
-			'name'        => esc_html__( 'Drip Message Without Date', 'sensei-content-drip' ),
-			'description' => esc_html__( 'The user will see this when the content is not yet available and we cannot compute a date for when it will become available', 'sensei-content-drip' ),
-			'type'        => 'textarea',
-			'default'     => esc_html__( 'This lesson is not available before starting the course.', 'sensei-content-drip' ),
-			'section'     => 'sensei-content-drip-settings',
-		);
-
 		$sensei_settings_fields['scd_drip_quiz_message'] = array(
 			'name'        => esc_html__( 'Quiz Drip Message', 'sensei-content-drip' ),
 			'description' => esc_html__( 'The user will see this on the lesson quiz when the lesson is not yet available. The [date] shortcode will be replaced by the actual date', 'sensei-content-drip' ),
 			'type'        => 'textarea',
 			'default'     => esc_html__( 'This quiz will become available on [date].', 'sensei-content-drip' ),
-			'section'     => 'sensei-content-drip-settings',
-		);
-
-		$sensei_settings_fields['scd_drip_quiz_message_without_date'] = array(
-			'name'        => esc_html__( 'Quiz Drip Message Without Date', 'sensei-content-drip' ),
-			'description' => esc_html__( 'The user will see this on the lesson quiz when the lesson is not yet available and we cannot compute a date for when it will become available', 'sensei-content-drip' ),
-			'type'        => 'textarea',
-			'default'     => esc_html__( 'This quiz is not available before starting the course.', 'sensei-content-drip' ),
 			'section'     => 'sensei-content-drip-settings',
 		);
 

--- a/includes/class-scd-ext-settings.php
+++ b/includes/class-scd-ext-settings.php
@@ -82,11 +82,27 @@ class Scd_Ext_Settings {
 			'section'     => 'sensei-content-drip-settings',
 		);
 
+		$sensei_settings_fields['scd_drip_message_without_date'] = array(
+			'name'        => esc_html__( 'Drip Message Without Date', 'sensei-content-drip' ),
+			'description' => esc_html__( 'The user will see this when the content is not yet available and we cannot compute a date for when it will become available', 'sensei-content-drip' ),
+			'type'        => 'textarea',
+			'default'     => esc_html__( 'This lesson is not available before starting the course.', 'sensei-content-drip' ),
+			'section'     => 'sensei-content-drip-settings',
+		);
+
 		$sensei_settings_fields['scd_drip_quiz_message'] = array(
 			'name'        => esc_html__( 'Quiz Drip Message', 'sensei-content-drip' ),
 			'description' => esc_html__( 'The user will see this on the lesson quiz when the lesson is not yet available. The [date] shortcode will be replaced by the actual date', 'sensei-content-drip' ),
 			'type'        => 'textarea',
 			'default'     => esc_html__( 'This quiz will become available on [date].', 'sensei-content-drip' ),
+			'section'     => 'sensei-content-drip-settings',
+		);
+
+		$sensei_settings_fields['scd_drip_quiz_message_without_date'] = array(
+			'name'        => esc_html__( 'Quiz Drip Message Without Date', 'sensei-content-drip' ),
+			'description' => esc_html__( 'The user will see this on the lesson quiz when the lesson is not yet available and we cannot compute a date for when it will become available', 'sensei-content-drip' ),
+			'type'        => 'textarea',
+			'default'     => esc_html__( 'This quiz is not available before starting the course.', 'sensei-content-drip' ),
 			'section'     => 'sensei-content-drip-settings',
 		);
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-content-drip/issues/121

See the issue for an explanation of the bug.

This solution blocks access for both lessons and quizzes.

### Notes

When trying to access a lesson or quiz whose content is not yet available, the error message specifies on which date the content will become available. However, when displaying the message for a user who has not started the course, this cannot be calculated for dynamic drip periods (i.e. drip periods that are a number of days after the course is started).

So for this case, we need to display a more generic message, simply saying that the lesson or quiz content is not available before starting the course. To remain consistent with the content that is already used, I added settings for customizing the new messages as well.

### Testing Instructions

- Create a course with a few lessons.

- Make one of the lessons drip at a specific date in the future, one on a specific date in the past, one on a number of days after completing the course, and have one not drip at all (the option "As soon as the course is started").

- As a logged-out user, visit each of the lessons. Ensure that you cannot see the content for any of the lessons that have not dripped yet. The one whose drip date is in the past, and the one with no drip set up should both be accessible.

- Validate the same things as a logged-in user who has not started the course.

- Also test with courses that are paid.