### PR TITLE
Ensure HTML escaping only occurs for strings

### DIFF
--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -491,7 +491,11 @@ class Scd_Ext_Lesson_Admin {
 
 			// Assign the key if a value exists
 			if ( ! empty( $value ) ) {
-				$lesson_drip_data[ $field_key ] = esc_html( $value );
+				// Ensure strings are HTML escaped.
+				if ( is_string( $value ) ) {
+					$value = esc_html( $value );
+				}
+				$lesson_drip_data[ $field_key ] = $value;
 			}
 		}
 


### PR DESCRIPTION
Fixes #124 

Note that I was not able to reproduce the fatal mentioned in that issue.

Also note that I built this on top of #146 in order to work with Sensei 2.0. I will rebase when #146 is merged.

## Testing instructions

See #124. Ensure content drip works.