### PR TITLE
Ensure emails are sent at 00:30 in the WordPress-configured timezone

### DIFF
--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -64,7 +64,11 @@ function sensei_content_drip_activation() {
 		wp_clear_scheduled_hook( $hook );
 	}
 
-	wp_schedule_event( time(), 'daily', $hook );
+	$today_start         = strtotime( date_i18n( 'Y-m-d' ) );
+	$tomorrow_start      = $today_start + 24 * HOUR_IN_SECONDS;
+	$scheduled_time      = $tomorrow_start + 30 * MINUTE_IN_SECONDS;
+	$scheduled_time_unix = $scheduled_time - get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+	wp_schedule_event( $scheduled_time_unix, 'daily', $hook );
 }
 
 


### PR DESCRIPTION
Fixes #91 

Schedules the cron job to run at 00:30 in the timezone set in the WordPress settings.

Note that I built this on top of #146 in order to work with Sensei 2.0. I will rebase when #146 is merged.

## Testing instructions

- Deactivate and reactivate the plugin.
- Inspect the cron jobs (the plugin [WP Crontrol](https://en-ca.wordpress.org/plugins/wp-crontrol/) is useful for this).
- Ensure the cron job `woo_scd_daily_cron_hook` is set to run tomorrow at 00:30 (12:30am) in the timezone configured in WordPress.
- In WordPress settings, change the timezone to one whose current date is different.
- Follow the steps above. Ensure the cron job is set to run on the following day at 00:30 relative to the configured timezone.