### PR TITLE
Use WordPress date format for Lesson table

### DIFF
--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -104,7 +104,7 @@ class Scd_Ext_Lesson_Admin {
 
 		if ( ctype_digit( $lesson_set_date ) ) {
 			// we are using new data in db, format accordingly
-			$lesson_set_date = date_i18n( self::DATE_FORMAT, $lesson_set_date );
+			$lesson_set_date = date_i18n( get_option( 'date_format', self::DATE_FORMAT ), $lesson_set_date );
 		}
 
 		return $lesson_set_date;

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -99,12 +99,18 @@ class Scd_Ext_Lesson_Admin {
 	 * @param  string $lesson_id
 	 * @return DateTime|string
 	 */
-	private function date_or_datestring_from_lesson( $lesson_id ) {
+	private function date_or_datestring_from_lesson( $lesson_id, $use_wp_format = false ) {
 		$lesson_set_date = get_post_meta( $lesson_id, '_sensei_content_drip_details_date', true );
 
 		if ( ctype_digit( $lesson_set_date ) ) {
+			$format = self::DATE_FORMAT;
+
+			if ( $use_wp_format ) {
+				$format = get_option( 'date_format', self::DATE_FORMAT );
+			}
+
 			// we are using new data in db, format accordingly
-			$lesson_set_date = date_i18n( get_option( 'date_format', self::DATE_FORMAT ), $lesson_set_date );
+			$lesson_set_date = date_i18n( $format, $lesson_set_date );
 		}
 
 		return $lesson_set_date;
@@ -131,7 +137,7 @@ class Scd_Ext_Lesson_Admin {
 		if ( 'none' === $drip_type ) {
 			echo esc_html__( 'Immediately', 'sensei-content-drip' );
 		} else if ( 'absolute' === $drip_type ) {
-			$lesson_set_date = $this->date_or_datestring_from_lesson( $lesson_id );
+			$lesson_set_date = $this->date_or_datestring_from_lesson( $lesson_id, true );
 			printf( esc_html__( 'On %s', 'sensei-content-drip' ), $lesson_set_date );
 		} else if ( 'dynamic' === $drip_type ) {
 			$unit_type   = get_post_meta( $lesson_id , '_sensei_content_drip_details_date_unit_type', true );


### PR DESCRIPTION
Closes #133 

This changes the date display for the Lessons table to match the format specified in the WordPress settings.

Note that it does not change the date format in the meta box, which was specified in #133. There are a few reasons for this:

- Since we are using a datepicker, the displayed format is probably not quite as important.
- We explicitly tell our users what format should be used in the input, and it is locale-independent.
- The available date format specifiers for the [datepicker](http://api.jqueryui.com/datepicker/#utility-formatDate) and the [WordPress setting](http://php.net/manual/en/function.date.php) do not match. It seems that it would be very difficult and error-prone to try to make the displayed format (which must work with the datepicker) exactly match the WordPress format.

I'm open to coming up with a solution for this if we feel that it is important enough.

## Testing Instructions

- Set a specific date for a lesson to drip.
- Load the Lessons table. Ensure the date is displayed in the format specified by the WordPress settings.
- Change the date format in the WordPress settings and reload the Lessons table. Ensure the date format in the table updates.