### PR TITLE
Don't use newer __DIR__ until after dependency check

### DIFF
--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -20,13 +20,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-require_once __DIR__ . '/includes/class-scd-ext-dependency-checker.php';
+require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
 if ( ! Scd_Ext_Dependency_Checker::are_dependencies_met() ) {
 	return;
 }
 
-require_once __DIR__ . '/includes/class-sensei-content-drip.php';
+require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
 
 /**
  * Returns the main instance of Sensei_Content_Drip to prevent the need to use globals.


### PR DESCRIPTION
Minor fix. In order to catch PHP 5.2, we need to delay using __DIR__ until a file loaded after the dependency checker.