### PR TITLE
Load plugin during `plugins_loaded`

### DIFF
--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -20,6 +20,7 @@ class Scd_Ext_Dependency_Checker {
 	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
 		}

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -36,16 +36,26 @@ class Scd_Ext_Dependency_Checker {
 	}
 
 	/**
-	 * Checks if all dependencies are met.
+	 * Checks if system dependencies are met.
 	 *
 	 * @return bool
 	 */
-	public static function are_dependencies_met() {
+	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
 		}
+		return $are_met;
+	}
+
+	/**
+	 * Checks if all plugin dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function are_plugin_dependencies_met() {
+		$are_met = true;
 		if ( ! self::check_sensei() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_sensei_notice' ) );
 			$are_met = false;

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -20,9 +20,11 @@ class Scd_Ext_Dependency_Checker {
 	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
-			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
+		}
+		if ( ! $are_met ) {
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
 		}
 		return $are_met;
 	}

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -13,29 +13,6 @@ class Scd_Ext_Dependency_Checker {
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 	/**
-	 * The list of active plugins.
-	 *
-	 * @var array
-	 */
-	private static $active_plugins;
-
-	/**
-	 * Get active plugins.
-	 *
-	 * @return string[]
-	 */
-	private static function get_active_plugins() {
-		if ( ! isset( self::$active_plugins ) ) {
-			self::$active_plugins = (array) get_option( 'active_plugins', array() );
-
-			if ( is_multisite() ) {
-				self::$active_plugins = array_merge( self::$active_plugins, get_site_option( 'active_sitewide_plugins', array() ) );
-			}
-		}
-		return self::$active_plugins;
-	}
-
-	/**
 	 * Checks if system dependencies are met.
 	 *
 	 * @return bool
@@ -78,23 +55,7 @@ class Scd_Ext_Dependency_Checker {
 	 * @return bool
 	 */
 	private static function check_sensei() {
-		$active_plugins = self::get_active_plugins();
-
-		$search_sensei = array(
-			'sensei/sensei.php',                     // Sensei 2.x from WordPress.org.
-			'sensei/woothemes-sensei.php',           // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-			'woothemes-sensei/woothemes-sensei.php', // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-		);
-
-		$found_sensei = false;
-		foreach ( $search_sensei as $basename ) {
-			if ( in_array( $basename, $active_plugins, true ) || array_key_exists( $basename, $active_plugins ) ) {
-				$found_sensei = true;
-				break;
-			}
-		}
-
-		if ( ! $found_sensei && ! class_exists( 'Sensei_Main' ) ) {
+		if ( ! class_exists( 'Sensei_Main' ) ) {
 			return false;
 		}
 

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -50,6 +50,13 @@ class Scd_Ext_Dependency_Checker {
 	}
 
 	/**
+	 * Deactivate self.
+	 */
+	public static function deactivate_self() {
+		deactivate_plugins( SENSEI_CONTENT_DRIP_PLUGIN_BASENAME );
+	}
+
+	/**
 	 * Checks for our Sensei dependency.
 	 *
 	 * @return bool

--- a/includes/class-sensei-content-drip.php
+++ b/includes/class-sensei-content-drip.php
@@ -112,9 +112,8 @@ class Sensei_Content_Drip {
 		$this->assets_url    = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_CONTENT_DRIP_PLUGIN_FILE ) ) );
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		register_activation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'install' ) );
-		register_deactivation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'on_deactivation' ) );
-
+		register_activation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'activate' ) );
+		register_deactivation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'deactivate' ) );
 	}
 
 	/**
@@ -279,7 +278,7 @@ class Sensei_Content_Drip {
 	 * @access private
 	 * @return void
 	 */
-	public function install() {
+	public function activate() {
 		$this->_log_version_number();
 
 		$hook = 'woo_scd_daily_cron_hook';
@@ -301,7 +300,7 @@ class Sensei_Content_Drip {
 	 * @since 2.0.0
 	 * @access private
 	 */
-	public function on_deactivation() {
+	public function deactivate() {
 		$hook = 'woo_scd_daily_cron_hook';
 		wp_clear_scheduled_hook( $hook );
 	}

--- a/includes/class-sensei-content-drip.php
+++ b/includes/class-sensei-content-drip.php
@@ -61,15 +61,6 @@ class Sensei_Content_Drip {
 	private $_token;
 
 	/**
-	 * The main plugin file.
-	 *
-	 * @var    string
-	 * @access private
-	 * @since  1.0.0
-	 */
-	private $file;
-
-	/**
 	 * The main plugin directory.
 	 *
 	 * @var    string
@@ -113,30 +104,50 @@ class Sensei_Content_Drip {
 	 * @param  string $file
 	 * @param  string $version
 	 */
-	public function __construct( $file, $version = '1.0.1' ) {
-		$this->_version      = $version;
+	public function __construct() {
+		$this->_version      = SENSEI_CONTENT_DRIP_VERSION;
 		$this->_token        = 'sensei_content_drip';
-		$this->file          = $file;
-		$this->dir           = dirname( $this->file );
+		$this->dir           = dirname( SENSEI_CONTENT_DRIP_PLUGIN_FILE );
 		$this->assets_dir    = trailingslashit( $this->dir ) . 'assets';
-		$this->assets_url    = esc_url( trailingslashit( plugins_url( '/assets/', $this->file ) ) );
+		$this->assets_url    = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_CONTENT_DRIP_PLUGIN_FILE ) ) );
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		register_activation_hook( $this->file, array( $this, 'install' ) );
+		register_activation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'install' ) );
+	}
+
+	/**
+	 * Set up all hooks and filters.
+	 */
+	public static function init() {
+		if ( ! Scd_Ext_Dependency_Checker::are_plugin_dependencies_met() ) {
+			return;
+		}
+
+		/**
+		 * Returns the main instance of Sensei_Content_Drip to prevent the need to use globals.
+		 *
+		 * @since  1.0.0
+		 * @return object Sensei_Content_Drip
+		 */
+		function Sensei_Content_Drip() {
+			return Sensei_Content_Drip::instance();
+		}
+
+		$instance = Sensei_Content_Drip();
 
 		// Load frontend JS & CSS
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ), 10 );
+		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );
 
 		// Load admin JS & CSS
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_scripts' ), 10, 1 );
-		add_action( 'admin_enqueue_scripts', array( $this, 'admin_enqueue_styles' ), 10, 1 );
+		add_action( 'admin_enqueue_scripts', array( $instance, 'admin_enqueue_scripts' ), 10, 1 );
+		add_action( 'admin_enqueue_scripts', array( $instance, 'admin_enqueue_styles' ), 10, 1 );
 
 		// Handle localisation
-		$this->load_plugin_textdomain ();
-		add_action( 'init', array( $this, 'load_localisation' ), 0 );
+		$instance->load_plugin_textdomain();
+		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
 
 		// Load and initialize classes
-		add_action( 'init', array( $this, 'initialize_classes' ), 0 );
+		add_action( 'init', array( $instance, 'initialize_classes' ), 0 );
 	}
 
 	/**
@@ -201,7 +212,7 @@ class Sensei_Content_Drip {
 	 * @return void
 	 */
 	public function load_localisation() {
-		load_plugin_textdomain( 'sensei-content-drip', false, dirname( plugin_basename( $this->file ) ) . '/lang/' );
+		load_plugin_textdomain( 'sensei-content-drip', false, dirname( SENSEI_CONTENT_DRIP_PLUGIN_BASENAME ) . '/lang/' );
 	}
 
 	/**
@@ -220,7 +231,7 @@ class Sensei_Content_Drip {
 		$locale = apply_filters( 'plugin_locale', get_locale(), $domain );
 
 		load_textdomain( $domain, WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain, false, dirname( plugin_basename( $this->file ) ) . '/lang/' );
+		load_plugin_textdomain( $domain, false, dirname( SENSEI_CONTENT_DRIP_PLUGIN_BASENAME ) . '/lang/' );
 	}
 
 	/**
@@ -233,9 +244,9 @@ class Sensei_Content_Drip {
 	 * @see    Sensei_Content_Drip()
 	 * @return Sensei_Content_Drip
 	 */
-	public static function instance( $file, $version = '1.0.1' ) {
+	public static function instance() {
 		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self( $file, $version );
+			self::$_instance = new self();
 		}
 
 		return self::$_instance;

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -7,7 +7,8 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Requires at least: 3.9
- * Tested up to: 4.7.2
+ * Tested up to: 5.1
+ * Requires PHP: 5.6
  * Domain path: /lang/
  * Woo: 543363:8ee2cdf89f55727f57733133ccbbfbb0
  *

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -37,3 +37,4 @@ require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
 // Load the plugin after all the other plugins have loaded.
 add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
 
+Sensei_Content_Drip::instance();

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -28,7 +28,7 @@ define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
 if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
-	deactivate_plugins( SENSEI_CONTENT_DRIP_PLUGIN_BASENAME );
+	add_action( 'admin_init', array( 'Scd_Ext_Dependency_Checker', 'deactivate_self' ) );
 	return;
 }
 

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -28,6 +28,7 @@ define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
 if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
+	deactivate_plugins( SENSEI_CONTENT_DRIP_PLUGIN_BASENAME );
 	return;
 }
 

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -28,7 +28,6 @@ define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
 if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
-	add_action( 'admin_init', array( 'Scd_Ext_Dependency_Checker', 'deactivate_self' ) );
 	return;
 }
 

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -32,7 +32,6 @@ if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
 
-
 // Load the plugin after all the other plugins have loaded.
 add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
 

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -20,26 +20,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'SENSEI_CONTENT_DRIP_VERSION', '2.0.0' );
+define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
+define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
 require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
-if ( ! Scd_Ext_Dependency_Checker::are_dependencies_met() ) {
+if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
 	return;
 }
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
 
-/**
- * Returns the main instance of Sensei_Content_Drip to prevent the need to use globals.
- *
- * @since  1.0.0
- * @return object Sensei_Content_Drip
- */
-function Sensei_Content_Drip() {
-	return Sensei_Content_Drip::instance( __FILE__, '2.0.0' );
-}
 
-// load this plugin only after sensei becomes available globaly
-add_action( 'plugins_loaded', 'Sensei_Content_Drip' ) ;
+// Load the plugin after all the other plugins have loaded.
+add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
 
 /**
  * Plugin Activation

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -35,34 +35,3 @@ require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
 // Load the plugin after all the other plugins have loaded.
 add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
 
-/**
- * Plugin Activation
- */
-register_activation_hook( __FILE__, 'sensei_content_drip_activation' );
-
-function sensei_content_drip_activation() {
-	$hook = 'woo_scd_daily_cron_hook';
-
-	if ( false !== wp_next_scheduled( $hook ) ) {
-		wp_clear_scheduled_hook( $hook );
-	}
-
-	$today_start         = strtotime( date_i18n( 'Y-m-d' ) );
-	$tomorrow_start      = $today_start + 24 * HOUR_IN_SECONDS;
-	$scheduled_time      = $tomorrow_start + 30 * MINUTE_IN_SECONDS;
-	$scheduled_time_unix = $scheduled_time - get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
-	wp_schedule_event( $scheduled_time_unix, 'daily', $hook );
-}
-
-
-/**
- * Plugin Deactivation
- */
-register_deactivation_hook( __FILE__, 'sensei_content_drip_deactivation' );
-
-function sensei_content_drip_deactivation() {
-	$hook = 'woo_scd_daily_cron_hook';
-	wp_clear_scheduled_hook( $hook );
-
-}
-


### PR DESCRIPTION
This PR: 
- Changes _plugin_ dependency checks until after plugins are first loaded. (https://github.com/woocommerce/sensei-course-progress/pull/68#issuecomment-472816337)
- Refactors a bit to make the above possible and match our other plugins.
- Consolidates activation hooks and moves deactivation hook to match.
- Self-deactivate if system dependencies aren't met.

In addition to the comments in #68, this is also necessary because we don't set up our activation hooks if the plugin dependencies aren't met.
### Testing Instructions
- If activated, deactivate all versions of Sensei. 
- Remove `sensei-version` and `woothemes-sensei-version` options.
- If not active, activate this plugin on built version of this branch. Verify the Sensei dependency message shows on Plugins page and Dashboard page.
- Activate Sensei 1.12.x. Verify message disappears.
- Deactivate Sensei 1.12.x. Activate Sensei 2.x. Verify message is still gone.
- Deactivate Sensei 2.x and activate Sensei with WooCommerce Paid Courses. Verify message is still gone.

Test PHP version:
- Activate Sensei and version of this branch on PHP 5.2-5.5. Verify PHP version notice appears.

In addition:
- Make sure cron events are loaded.
- Make sure version is logged in options (`sensei_content_drip_version`) on activation even when Sensei isn't first activated.