### PR TITLE
Replace usage of `create_function()`

### DIFF
--- a/includes/class-scd-ext-drip-email.php
+++ b/includes/class-scd-ext-drip-email.php
@@ -436,11 +436,10 @@ class Scd_Ext_Drip_Email {
 
 		/**
 		 * Swap keys and values so we can use the order given
-		 * as the index for the values that should be returned
-		 * fill t
+		 * as the index for the values that should be returned.
 		 */
 		$ordered_lessons = array_flip( $ordered_lessons );
-		$ordered_lessons = array_map( create_function( '$n', 'return false;' ), $ordered_lessons );
+		$ordered_lessons = array_map( '__return_false', $ordered_lessons );
 
 		foreach ( $lessons as $lesson_id => $lesson_line_item ) {
 			$ordered_lessons[ $lesson_id ] = $lesson_line_item;


### PR DESCRIPTION
`create_function()` was deprecated in PHP 7.2 and will be removed. This was really easy to replace.

### Testing Instructions

To test, add multiple lessons to slow drip course that drop on the same day. Send a test email and verify no PHP warnings get logged.