### PR TITLE
Load text domain and localizations slightly earlier

### DIFF
--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -88,7 +88,7 @@ class Scd_Ext_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that SCD requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei Content Drip</strong> requires PHP version %1$s but you are running %2$s.', 'sensei-content-drip' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>Sensei Content Drip</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-content-drip' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		$php_update_url = 'https://wordpress.org/support/update-php/';

--- a/includes/class-sensei-content-drip.php
+++ b/includes/class-sensei-content-drip.php
@@ -112,6 +112,10 @@ class Sensei_Content_Drip {
 		$this->assets_url    = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_CONTENT_DRIP_PLUGIN_FILE ) ) );
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
+		// Handle localisation.
+		$this->load_plugin_textdomain();
+		add_action( 'init', array( $this, 'load_localisation' ), 0 );
+
 		register_activation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'activate' ) );
 		register_deactivation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'deactivate' ) );
 	}
@@ -142,10 +146,6 @@ class Sensei_Content_Drip {
 		// Load admin JS & CSS
 		add_action( 'admin_enqueue_scripts', array( $instance, 'admin_enqueue_scripts' ), 10, 1 );
 		add_action( 'admin_enqueue_scripts', array( $instance, 'admin_enqueue_styles' ), 10, 1 );
-
-		// Handle localisation
-		$instance->load_plugin_textdomain();
-		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
 
 		// Load and initialize classes
 		add_action( 'init', array( $instance, 'initialize_classes' ), 0 );

--- a/includes/class-sensei-content-drip.php
+++ b/includes/class-sensei-content-drip.php
@@ -112,9 +112,7 @@ class Sensei_Content_Drip {
 		$this->assets_url    = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_CONTENT_DRIP_PLUGIN_FILE ) ) );
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		// Handle localisation.
 		$this->load_plugin_textdomain();
-		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 
 		register_activation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'activate' ) );
 		register_deactivation_hook( SENSEI_CONTENT_DRIP_PLUGIN_FILE, array( $this, 'deactivate' ) );
@@ -124,6 +122,9 @@ class Sensei_Content_Drip {
 	 * Set up all hooks and filters.
 	 */
 	public static function init() {
+		$instance = self::instance();
+		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
+
 		if ( ! Scd_Ext_Dependency_Checker::are_plugin_dependencies_met() ) {
 			return;
 		}
@@ -137,8 +138,6 @@ class Sensei_Content_Drip {
 		function Sensei_Content_Drip() {
 			return Sensei_Content_Drip::instance();
 		}
-
-		$instance = Sensei_Content_Drip();
 
 		// Load frontend JS & CSS
 		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );


### PR DESCRIPTION
As I've been working through the other plugins, I've started loading the localizations and textdomain slightly earlier. I'd like to change this here for consistency. This should also allow our plugin dependency notice to be localized. Unfortunately, our PHP notice probably won't get localized.