### PR TITLE
Add filter to hide comments when lesson is blocked

### DIFF
--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -47,13 +47,16 @@ class Scd_Ext_Lesson_Frontend {
 	 * Constructor function
 	 */
 	public function __construct() {
-		// Set a formatted  message shown to user when the content has not yet dripped
-		$default_message = 'This lesson will become available on [date].';
-		$settings_field =  'scd_drip_message';
-		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation($default_message, $settings_field );
+		// Set a formatted  message shown to user when the content has not yet dripped.
+		$default_message      = 'This lesson will become available on [date].';
+		$settings_field       = 'scd_drip_message';
+		$this->message_format = Sensei_Content_Drip()->utils->check_for_translation( $default_message, $settings_field );
 
-		// Hook int all post of type lesson to determine if they should be
-		add_filter('the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );
+		// Hook int all post of type lesson to determine if they should be.
+		add_filter( 'the_posts', array( $this, 'lesson_content_drip_filter' ), 1 );
+
+		// Add action to not display comments if the lesson is blocked.
+		add_action( 'sensei_pagination', array( $this, 'hide_comments' ) );
 	}
 
 	/**
@@ -95,6 +98,23 @@ class Scd_Ext_Lesson_Frontend {
 		}
 
 		return $lessons;
+	}
+
+	/**
+	 * Hides the comments if the lesson is blocked by content drip.
+	 *
+	 * @since  2.0.1
+	 * @access private
+	 */
+	public function hide_comments() {
+
+		if ( 'lesson' !== get_post_type() ) {
+			return;
+		}
+
+		if ( Sensei_Content_Drip::instance()->access_control->is_lesson_access_blocked( get_the_ID() ) ) {
+			remove_action( 'sensei_pagination', array( 'Sensei_Lesson', 'output_comments' ), 90 );
+		}
 	}
 
 	/**

--- a/includes/class-sensei-content-drip.php
+++ b/includes/class-sensei-content-drip.php
@@ -14,6 +14,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author WooThemes
  * @since 1.0.0
  *
+ * @property Scd_Ext_Settings $settings
+ * @property Scd_Ext_Utils $utils
+ * @property Scd_Ext_Access_Control $access_control
+ * @property Scd_Ext_Lesson_Frontend $lesson_frontend
+ * @property Scd_Ext_Lesson_Admin $lesson_admin
+ * @property Scd_Ext_Quiz_Frontend $quiz_frontend
+ * @property Scd_Ext_Drip_Email $drip_email
+ * @property Scd_Ext_Manual_Drip $manual_drip
+ *
  * Table Of Contents:
  * - __construct
  * - enqueue_styles


### PR DESCRIPTION
Fixes #139 

### Overview
This change fixes the issue that lesson comments where visible although the lesson was not accessible due to content drip. It relies on the filter that was added with [this](https://github.com/Automattic/sensei/pull/2795) PR.

### Testing

1. In Sensei settings, make sure that General->Access Permissions and Lessons->Allow Comments for Lessons are enabled.
2. Create a lesson and with a user add a comment to it.
3. By using content drip, make the lesson inaccessible by setting a future date that it will be accessible.
4. With another user subscribe to the course.
5. Open the lesson page and observe that the comments are not displayed.
6. Update the lesson again to make it accessible.
7. Check again and see that now the comments are displayed.

### Notes
This change has a dependency on [this change](https://github.com/Automattic/sensei/pull/2795) in Sensei core. Although there will be no errors if one of the two is merged without the other, we need both for the functionality to work.