### PR TITLE
Switch user_started_course to is_user_enrolled

### DIFF
--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -76,7 +76,11 @@ class Scd_Ext_Access_Control {
 		}
 
 		// Check if user has started the course.
-		$user_started_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
+		if ( Sensei_Content_Drip::instance()->is_legacy_enrolment() ) {
+			$user_started_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
+		} else {
+			$user_started_course = Sensei_Course::is_user_enrolled( $lesson_course_id );
+		}
 
 		// get the lessons drip data if any
 		$drip_type = get_post_meta( $lesson_id , '_sensei_content_drip_type', true );
@@ -127,10 +131,15 @@ class Scd_Ext_Access_Control {
 	public function sensei_should_block_lesson( $lesson_id, $user_id ) {
 		$lesson_course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
+		if ( Sensei_Content_Drip::instance()->is_legacy_enrolment() ) {
+			$user_started_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
+		} else {
+			$user_started_course = Sensei_Course::is_user_enrolled( $lesson_course_id );
+		}
+
 		// Block the lesson only if user has not started the course and it
 		// hasn't dripped yet.
-		return ! Sensei_Utils::user_started_course( $lesson_course_id, $user_id )
-			&& $this->is_lesson_access_blocked( $lesson_id );
+		return ! $user_started_course && $this->is_lesson_access_blocked( $lesson_id );
 	}
 
 	/**

--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -132,14 +132,13 @@ class Scd_Ext_Access_Control {
 		$lesson_course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
 		if ( Sensei_Content_Drip::instance()->is_legacy_enrolment() ) {
-			$user_started_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
+			$is_enrolled = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
 		} else {
-			$user_started_course = Sensei_Course::is_user_enrolled( $lesson_course_id );
+			$is_enrolled = Sensei_Course::is_user_enrolled( $lesson_course_id );
 		}
 
-		// Block the lesson only if user has not started the course and it
-		// hasn't dripped yet.
-		return ! $user_started_course && $this->is_lesson_access_blocked( $lesson_id );
+		// Block the lesson only if user is not enrolled and it hasn't dripped yet.
+		return ! $is_enrolled && $this->is_lesson_access_blocked( $lesson_id );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This change switches usages of `Sensei_Utils::user_started_course` to `Sensei_Course::is_user_enrolled`. The calls to `Sensei_Utils::user_started_course` can't be removed completely since we must support pre v3 core Sensei.

#### Testing instructions:

* Create a course and link it to a product. Add two lessons to it which drip in the future. One lesson should drip to a static date and one on a date which is based on user's start date.
* Check that a user that bought the product can't access the lessons.
* Disable 'Access Permissions' setting.
* Check that the user still can't access lessons.
* Logout and check that the lessons still can't be accessed.
* Remove the content drip dates from lessons and check that the lessons can be accessed.