### PR TITLE
Disable all content hooks if lesson is not available

### DIFF
--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -171,16 +171,13 @@ class Scd_Ext_Lesson_Frontend {
 		// Hide the lesson quiz notice and quiz buttons
 		remove_all_actions( 'sensei_lesson_quiz_meta' );
 
-		// Hide buttons from sensei version 1.9 onwards
-		remove_action( 'sensei_single_lesson_content_inside_after', array( 'Sensei_Lesson', 'footer_quiz_call_to_action' ) );
-
-		// Hide the lesson quiz notice
-		remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
+		// Disable lesson content hooks.
+		remove_all_actions( 'sensei_single_lesson_content_inside_after' );
+		remove_all_actions( 'sensei_single_lesson_content_inside_before' );
 
 		// Hide lesson meta (e.g. Media from Sensei-Media-Items.)
 		remove_all_actions( 'sensei_lesson_single_meta' );
 	}
-
 
 	/**
 	 * Check if the lesson can be made available to the the user at this point


### PR DESCRIPTION
Fixes #199

### Changes proposed in this Pull Request

* Remove all actions from the `sensei_single_lesson_content_inside_before` and `sensei_single_lesson_content_inside_after` hooks if the lesson hasn't dripped yet. 

### Testing instructions

* Activate the Media attachments plugin and add attachments to a lesson.
* Set that lesson to be available in a future date in the Content Drip metabox.
* Start the course with a new user and open the lesson.
* Make sure no lesson content is visible, including the Lesson Media attached in the first step.

