### PR TITLE
Remove PHP 5.6 test from CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 build
 assets/dist
 /*.zip
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,6 @@ before_script:
 jobs:
   include:
     - stage: test
-      php: 5.6
-      env: WP_VERSION=latest SENSEI_VERSION=master
-      script:
-        - ./tests/bin/travis-phpunit.sh
-    - stage: test
       php: 7.0
       env: WP_VERSION=latest SENSEI_VERSION=master
       script:


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Remove the PHP 5.6 test run from Travis. Since Sensei `master` requires PHP 7.0 now, it's failing
* Minimum PHP version is not bumped for now since it could cause issues with auto-updating from WC.com

### Testing instructions

* Travis green
