### PR TITLE
Use WordPress timezone when dripping lessons

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Sensei LMS Content Drip",
   "require-dev": {
     "php": "^7",
+    "phpunit/phpunit": "6.5.14",
     "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
     "phpcompatibility/phpcompatibility-wp": "2.1.0",
     "squizlabs/php_codesniffer": "3.5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c44cdc32b63d3ff9f806b6631f5e4f5",
+    "content-hash": "74c5773954094cd1b028ed175d0b8881",
     "packages": [],
     "packages-dev": [
         {
@@ -71,7 +71,248 @@
                 "stylecheck",
                 "tests"
             ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
             "time": "2020-06-25T14:57:39+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/master"
+            },
+            "time": "2017-03-05T17:38:23+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -129,6 +370,10 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
@@ -181,6 +426,10 @@
                 "polyfill",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
             "time": "2019-11-04T15:17:54+00:00"
         },
         {
@@ -231,7 +480,1292 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
             "time": "2019-08-28T14:22:28+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
+            "time": "2020-09-03T19:13:55+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
+            "time": "2020-09-17T18:55:26+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5 || ^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
+            },
+            "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "5.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
+                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^2.0.1",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.5.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/5.3"
+            },
+            "time": "2018-04-06T15:36:58+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+            },
+            "time": "2017-11-27T13:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+            },
+            "time": "2017-02-26T11:10:40+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
+            },
+            "abandoned": true,
+            "time": "2017-11-27T05:48:46+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "6.5.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^1.0.9",
+                "phpunit/phpunit-mock-objects": "^5.0.9",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^2.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/6.5.14"
+            },
+            "time": "2019-02-01T05:22:47+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "5.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.5.11"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/5.0.10"
+            },
+            "abandoned": true,
+            "time": "2018-08-09T05:50:03+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:15:22+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/master"
+            },
+            "time": "2018-02-01T13:46:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/master"
+            },
+            "time": "2017-08-03T08:09:46+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/master"
+            },
+            "time": "2017-07-01T08:51:00+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:47:53+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/2.0.0"
+            },
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:40:27+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:37:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:34:24+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+            },
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -282,7 +1816,194 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-08-10T04:50:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.20-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-23T14:02:19+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
+            "time": "2020-07-08T17:02:28+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -328,6 +2049,11 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
             "time": "2020-05-13T23:57:56+00:00"
         }
     ],
@@ -340,5 +2066,5 @@
     "platform-dev": {
         "php": "^7"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/includes/class-scd-ext-access-control.php
+++ b/includes/class-scd-ext-access-control.php
@@ -172,7 +172,7 @@ class Scd_Ext_Access_Control {
 
 		// Convert string dates to date object.
 		$lesson_drip_date = $this->get_lesson_drip_date( $lesson_id , $user_id );
-		$today            = current_datetime()->setTime( 0, 0, 0 );
+		$today            = Sensei_Content_Drip()->utils->current_datetime()->setTime( 0, 0, 0 );
 
 		if ( ! $lesson_drip_date ) {
 			return $access_blocked;
@@ -233,7 +233,7 @@ class Scd_Ext_Access_Control {
 		}
 
 		$lesson_becomes_available_date = $this->get_lesson_drip_date( $lesson_id , $user_id );
-		$today                         = current_datetime()->setTime( 0, 0, 0 );
+		$today                         = Sensei_Content_Drip()->utils->current_datetime()->setTime( 0, 0, 0 );
 
 		if ( ! $lesson_becomes_available_date ) {
 			return $access_blocked;
@@ -318,7 +318,7 @@ class Scd_Ext_Access_Control {
 			$user_course_start_date = new DateTimeImmutable( $user_course_start_date_string, $timezone );
 
 			// Standardize this to the WP timezone.
-			$user_course_start_date = $user_course_start_date->setTimezone( wp_timezone() );
+			$user_course_start_date = $user_course_start_date->setTimezone( Sensei_Content_Drip()->utils->wp_timezone() );
 
 			// Create a date interval object to determine when the lesson should become available
 			$unit_type_first_letter_uppercase = strtoupper( substr( $unit_type, 0, 1 ) ) ;
@@ -370,4 +370,5 @@ class Scd_Ext_Access_Control {
 
 		return in_array( $course_id, $teacher_courses_id );
 	}
+
 }

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -26,9 +26,9 @@ class Scd_Ext_Dependency_Checker {
 			$are_met = false;
 		}
 
+		// WordPress check is soft requirement for now.
 		if ( ! self::check_wp() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_wp_notice' ) );
-			$are_met = false;
 		}
 
 		if ( ! $are_met ) {

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  */
 class Scd_Ext_Dependency_Checker {
-	const MINIMUM_PHP_VERSION    = '5.6';
+	const MINIMUM_PHP_VERSION    = '7.0';
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 	const MINIMUM_WP_VERSION     = '5.3';
 

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -21,14 +21,14 @@ class Scd_Ext_Dependency_Checker {
 	public static function are_system_dependencies_met() {
 		$are_met = true;
 
-		if ( ! self::check_php() ) {
-			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
+		if ( ! self::check_php_version() ) {
+			add_action( 'admin_notices', array( __CLASS__, 'add_php_version_notice' ) );
 			$are_met = false;
 		}
 
 		// WordPress check is soft requirement for now.
-		if ( ! self::check_wp() ) {
-			add_action( 'admin_notices', array( __CLASS__, 'add_wp_notice' ) );
+		if ( ! self::check_wp_version() ) {
+			add_action( 'admin_notices', array( __CLASS__, 'add_wp_version_notice' ) );
 		}
 
 		if ( ! $are_met ) {
@@ -57,7 +57,7 @@ class Scd_Ext_Dependency_Checker {
 	 *
 	 * @return bool
 	 */
-	private static function check_php() {
+	private static function check_php_version() {
 		return version_compare( phpversion(), self::MINIMUM_PHP_VERSION, '>=' );
 	}
 
@@ -66,7 +66,7 @@ class Scd_Ext_Dependency_Checker {
 	 *
 	 * @return bool
 	 */
-	private static function check_wp() {
+	private static function check_wp_version() {
 		global $wp_version;
 
 		return version_compare( $wp_version, self::MINIMUM_WP_VERSION, '>=' );
@@ -99,7 +99,7 @@ class Scd_Ext_Dependency_Checker {
 	 *
 	 * @access private
 	 */
-	public static function add_php_notice() {
+	public static function add_php_version_notice() {
 		$screen        = get_current_screen();
 		$valid_screens = array( 'dashboard', 'plugins' );
 
@@ -130,7 +130,7 @@ class Scd_Ext_Dependency_Checker {
 	 *
 	 * @access private
 	 */
-	public static function add_wp_notice() {
+	public static function add_wp_version_notice() {
 		global $wp_version;
 
 		$screen        = get_current_screen();

--- a/includes/class-scd-ext-drip-email.php
+++ b/includes/class-scd-ext-drip-email.php
@@ -199,7 +199,7 @@ class Scd_Ext_Drip_Email {
 	function is_dripping_today( $lesson_id, $user_id = '' ) {
 		// Setup variables needed.
 		$dripping_today = false;
-		$today          = current_datetime()->setTime( 0, 0, 0 );
+		$today          = Sensei_Content_Drip()->utils->current_datetime()->setTime( 0, 0, 0 );
 
 		// Get the lesson drip date.
 		$lesson_drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( absint( $lesson_id ), absint( $user_id ) );

--- a/includes/class-scd-ext-drip-email.php
+++ b/includes/class-scd-ext-drip-email.php
@@ -199,7 +199,7 @@ class Scd_Ext_Drip_Email {
 	function is_dripping_today( $lesson_id, $user_id = '' ) {
 		// Setup variables needed.
 		$dripping_today = false;
-		$today          = new DateTime( date( 'Y-m-d' ) ); // Get the date ignoring H:M:S.
+		$today          = current_datetime()->setTime( 0, 0, 0 );
 
 		// Get the lesson drip date.
 		$lesson_drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( absint( $lesson_id ), absint( $user_id ) );

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -97,7 +97,7 @@ class Scd_Ext_Lesson_Admin {
 	 * Attempts to retrieve the date in localized format (if using new format), otherwise return plain format
 	 *
 	 * @param  string $lesson_id
-	 * @return DateTime|string
+	 * @return string
 	 */
 	private function date_or_datestring_from_lesson( $lesson_id, $use_wp_format = false ) {
 		$lesson_set_date = get_post_meta( $lesson_id, '_sensei_content_drip_details_date', true );
@@ -110,7 +110,9 @@ class Scd_Ext_Lesson_Admin {
 			}
 
 			// we are using new data in db, format accordingly
-			$lesson_set_date = date_i18n( $format, $lesson_set_date );
+			$lesson_set_date = DateTimeImmutable::createFromFormat( 'U', $lesson_set_date )->setTimezone( wp_timezone() );
+
+			$lesson_set_date = $lesson_set_date->format( $format );
 		}
 
 		return $lesson_set_date;
@@ -345,11 +347,11 @@ class Scd_Ext_Lesson_Admin {
 
 			// we are always expecting a specific time format for this field in the form of
 
-			$date = DateTime::createFromFormat( self::DATE_FORMAT, $date_string );
+			$date = DateTimeImmutable::createFromFormat( self::DATE_FORMAT, $date_string, wp_timezone() );
 			if (false === $date) {
 				// possibly legacy, try to match the format from wp settings
 				$date_format = get_option( 'date_format' );
-				$date = DateTime::createFromFormat( $date_format, $date_string );
+				$date = DateTimeImmutable::createFromFormat( $date_format, $date_string, wp_timezone() );
 				if (false === $date) {
 					// at this point we can't do somthing so we
 					// need to prompt the user to reselect a date from the
@@ -360,7 +362,8 @@ class Scd_Ext_Lesson_Admin {
 					return $post_id;
 				}
 			}
-			$date_string = $date->getTimestamp();
+
+			$date_string = $date->setTime( 0, 0, 0 )->getTimestamp();
 
 			// Set the meta data to be saves later
 			// Set the mets data to ready to pass it onto saving

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -383,7 +383,7 @@ class Scd_Ext_Lesson_Admin {
 				$save_error_notices = array( 'error' => esc_html__( 'Please select the correct units for your chosen option "After previous lesson" .', 'sensei-content-drip' ) );
 				$dynamic_save_error = true;
 			} else if ( ! is_numeric( $date_unit_amount ) ) {
-				$save_error_notices = array( 'error' => esc_html__( 'Please enter a numberic unit number for your chosen option "After previous lesson" .', 'sensei-content-drip' ) );
+				$save_error_notices = array( 'error' => esc_html__( 'Please enter a unit number for your chosen option "After previous lesson" .', 'sensei-content-drip' ) );
 				$dynamic_save_error = true;
 			}
 

--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -110,7 +110,7 @@ class Scd_Ext_Lesson_Admin {
 			}
 
 			// we are using new data in db, format accordingly
-			$lesson_set_date = DateTimeImmutable::createFromFormat( 'U', $lesson_set_date )->setTimezone( wp_timezone() );
+			$lesson_set_date = DateTimeImmutable::createFromFormat( 'U', $lesson_set_date )->setTimezone( Sensei_Content_Drip()->utils->wp_timezone() );
 
 			$lesson_set_date = $lesson_set_date->format( $format );
 		}
@@ -346,12 +346,12 @@ class Scd_Ext_Lesson_Admin {
 
 
 			// we are always expecting a specific time format for this field in the form of
-
-			$date = DateTimeImmutable::createFromFormat( self::DATE_FORMAT, $date_string, wp_timezone() );
+			$timezone = Sensei_Content_Drip()->utils->wp_timezone();
+			$date     = DateTimeImmutable::createFromFormat( self::DATE_FORMAT, $date_string, $timezone );
 			if (false === $date) {
 				// possibly legacy, try to match the format from wp settings
 				$date_format = get_option( 'date_format' );
-				$date = DateTimeImmutable::createFromFormat( $date_format, $date_string, wp_timezone() );
+				$date = DateTimeImmutable::createFromFormat( $date_format, $date_string, $timezone );
 				if (false === $date) {
 					// at this point we can't do somthing so we
 					// need to prompt the user to reselect a date from the

--- a/includes/class-scd-ext-lesson-frontend.php
+++ b/includes/class-scd-ext-lesson-frontend.php
@@ -220,15 +220,11 @@ class Scd_Ext_Lesson_Frontend {
 	 * @return bool
 	 */
 	public function generate_absolute_drip_type_message( $lesson_id ) {
-		$absolute_drip_type_message = '';
-
-		// Get this lessons drip data
+		// Get this lessons drip data.
 		$lesson_drip_date = Scd_Ext_Utils::date_from_datestring_or_timestamp( $lesson_id );
-		$lesson_drip_timestamp = $lesson_drip_date->getTimestamp();
+		$formatted_date   = $lesson_drip_date->format( get_option( 'date_format' ) );
 
-		$formatted_date = date_i18n( get_option( 'date_format' ), $lesson_drip_timestamp );
-
-		// Replace the shortcode in the class message_format property set in the constructor
+		// Replace the shortcode in the class message_format property set in the constructor.
 		if ( strpos( $this->message_format , '[date]' ) ) {
 			$absolute_drip_type_message = str_replace( '[date]', $formatted_date, $this->message_format );
 		} else {
@@ -247,16 +243,15 @@ class Scd_Ext_Lesson_Frontend {
 	 * @return bool $dripped
 	 */
 	public function generate_dynamic_drip_type_message( $lesson_id ) {
-		$current_user              = wp_get_current_user();
-		$user_id                   = $current_user->ID;
-		$dynamic_drip_type_message = '';
-		$lesson_available_date     = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id , $user_id );
+		$current_user          = wp_get_current_user();
+		$user_id               = $current_user->ID;
+		$lesson_available_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id , $user_id );
 
 		if ( ! $lesson_available_date ) {
 			return '';
 		}
 
-		$formatted_date            = date_i18n( get_option( 'date_format' ), $lesson_available_date->getTimestamp() );
+		$formatted_date = $lesson_available_date->format( get_option( 'date_format' ) );
 
 		// Replace string content in the class message_format property set in the constructor
 		$dynamic_drip_type_message = str_replace( '[date]', $formatted_date, $this->message_format );

--- a/includes/class-scd-ext-utilities.php
+++ b/includes/class-scd-ext-utilities.php
@@ -101,13 +101,14 @@ class Scd_Ext_Utils {
 	 */
 	public static function date_from_datestring_or_timestamp( $lesson_id ) {
 		$lesson_set_date = get_post_meta( $lesson_id, '_sensei_content_drip_details_date', true );
+		$timezone        = Sensei_Content_Drip()->utils->wp_timezone();
 
 		if ( ! ctype_digit( $lesson_set_date ) ) {
 			// backwards compatibility for data that's still using the old format
-			$drip_date = new DateTimeImmutable( $lesson_set_date, wp_timezone() );
+			$drip_date = new DateTimeImmutable( $lesson_set_date, $timezone );
 		} else {
 			$drip_date = DateTimeImmutable::createFromFormat( 'U', $lesson_set_date );
-			$drip_date = $drip_date->setTimezone( wp_timezone() );
+			$drip_date = $drip_date->setTimezone( $timezone );
 		}
 
 		return $drip_date;
@@ -137,5 +138,31 @@ class Scd_Ext_Utils {
 		return ( empty( $settings_message ) ) ? $default_message : $settings_message;
     } // end check_for_translation()
 
+	/**
+	 * Get the current datetime as a DateTimeImmutable object.
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function current_datetime() {
+		// Provide light compatibility pre-WP 5.3. This won't be smart about timezones.
+		if ( ! function_exists( 'current_datetime' ) ) {
+			return new DateTimeImmutable();
+		}
+
+		return current_datetime();
+	}
+
+	/**
+	 * Get the current WP Timezone.
+	 * @return DateTimeZone
+	 */
+	public function wp_timezone() {
+		// Provide light compatibility pre-WP 5.3. This won't be smart about timezones.
+		if ( ! function_exists( 'wp_timezone' ) ) {
+			return new DateTimeZone( 'UTC' );
+		}
+
+		return wp_timezone();
+	}
 } // end class Sensei_Scd_Extension_Utils
 

--- a/includes/class-scd-ext-utilities.php
+++ b/includes/class-scd-ext-utilities.php
@@ -97,18 +97,18 @@ class Scd_Ext_Utils {
 	 * Return a DateTime object for the given lesson ID (bwc support)
 	 *
 	 * @param  string $lesson_id
-	 * @return DateTime|bool
+	 * @return DateTimeImmutable|bool
 	 */
 	public static function date_from_datestring_or_timestamp( $lesson_id ) {
 		$lesson_set_date = get_post_meta( $lesson_id, '_sensei_content_drip_details_date', true );
 
 		if ( ! ctype_digit( $lesson_set_date ) ) {
 			// backwards compatibility for data that's still using the old format
-			$drip_date = new DateTime( $lesson_set_date );
+			$drip_date = new DateTimeImmutable( $lesson_set_date, wp_timezone() );
 		} else {
-			$drip_date = DateTime::createFromFormat( 'U', $lesson_set_date );
+			$drip_date = DateTimeImmutable::createFromFormat( 'U', $lesson_set_date );
+			$drip_date = $drip_date->setTimezone( wp_timezone() );
 		}
-
 
 		return $drip_date;
 	}

--- a/includes/class-scd-ext-utilities.php
+++ b/includes/class-scd-ext-utilities.php
@@ -146,7 +146,7 @@ class Scd_Ext_Utils {
 	public function current_datetime() {
 		// Provide light compatibility pre-WP 5.3. This won't be smart about timezones.
 		if ( ! function_exists( 'current_datetime' ) ) {
-			return new DateTimeImmutable();
+			return new DateTimeImmutable( 'now', $this->wp_timezone() );
 		}
 
 		return current_datetime();

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "packages-update": "wp-scripts packages-update",
     "start": "wp-scripts start",
     "i18n:build": "npm run i18n:php",
-    "i18n:php": "wp i18n make-pot --exclude=lib,vendor,node_modules --skip-js --headers='{\"Last-Translator\":null,\"Language-Team\":null,\"Report-Msgid-Bugs-To\":\"https://woocommerce.com/support\"}' . lang/sensei-content-drip.pot"
+    "i18n:php": "wp i18n make-pot --exclude=lib,vendor,node_modules --skip-js --headers='{\"Last-Translator\":null,\"Language-Team\":null,\"Report-Msgid-Bugs-To\":\"https://woocommerce.com/support\"}' . lang/sensei-content-drip.pot",
+    "test-php": "./vendor/bin/phpunit"
   }
 }

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -6,9 +6,9 @@
  * Description:  Control access to Sensei lessons by scheduling them to become available after a determined time.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Requires at least: 3.9
- * Tested up to: 5.1
- * Requires PHP: 5.6
+ * Requires at least: 5.3
+ * Tested up to: 5.6
+ * Requires PHP: 7.0
  * Domain path: /lang/
  * Woo: 543363:8ee2cdf89f55727f57733133ccbbfbb0
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -38,6 +38,7 @@ class Sensei_Content_Drip_Unit_Tests_Bootstrap {
 		$this->plugin_dir                  = dirname( $this->tests_dir );
 		$this->wp_tests_dir                = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
 		$this->sensei_plugin_dir           = getenv( 'SENSEI_PLUGIN_DIR' ) ? getenv( 'SENSEI_PLUGIN_DIR' ) : '/tmp/sensei-master';
+		$this->sensei_tests_framework_dir  = $this->sensei_plugin_dir . '/tests/framework';
 
 		if (
 			! file_exists( $this->wp_tests_dir . '/includes/functions.php' )
@@ -59,6 +60,15 @@ class Sensei_Content_Drip_Unit_Tests_Bootstrap {
 
 		// Load the WP testing environment.
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
+
+		// Load the Sensei testing framework.
+		require_once $this->sensei_tests_framework_dir . '/factories/class-sensei-factory.php';
+		require_once $this->sensei_tests_framework_dir . '/factories/class-wp-unittest-factory-for-post-sensei.php';
+		require_once $this->sensei_tests_framework_dir . '/trait-sensei-test-login-helpers.php';
+
+		// Load this plugin's test framework.
+		require_once $this->tests_dir . '/framework/drip-test-helpers.php';
+		require_once $this->tests_dir . '/framework/class-time-machine.php';
 	}
 
 	/**

--- a/tests/framework/class-time-machine.php
+++ b/tests/framework/class-time-machine.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Scd_Ext\Tests;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Scd_Ext_Utils;
+
+class Time_Machine extends Scd_Ext_Utils {
+	private static $utils_original;
+	private static $instance;
+	private static $now;
+	private static $timezone;
+
+	public static function activate( $reset = true ) {
+		if ( ! isset( self::$utils_original ) ) {
+			self::$utils_original = Sensei_Content_Drip()->utils;
+		}
+
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new static;
+		}
+
+		Sensei_Content_Drip()->utils = self::$instance;
+
+		if ( $reset ) {
+			self::reset();
+		}
+	}
+
+	public static function deactivate() {
+		if ( isset( self::$utils_original ) ) {
+			Sensei_Content_Drip()->utils = self::$utils_original;
+		}
+	}
+
+	public static function reset() {
+		self::$now      = null;
+		self::$timezone = null;
+	}
+
+	public static function set_datetime( DateTimeImmutable $datetime ) {
+		self::$now = $datetime;
+	}
+
+	public static function set_timezone( DateTimeZone $timezone ) {
+		self::$timezone = $timezone;
+	}
+
+	public function current_datetime() {
+		if ( isset( self::$now ) ) {
+			return self::$now;
+		}
+
+		return new DateTimeImmutable( 'now', $this->wp_timezone() );
+	}
+
+	public function wp_timezone() {
+		if ( isset( self::$timezone ) ) {
+			return self::$timezone;
+		}
+
+		return parent::wp_timezone();
+	}
+
+
+}

--- a/tests/framework/class-time-machine.php
+++ b/tests/framework/class-time-machine.php
@@ -7,11 +7,38 @@ use DateTimeZone;
 use Scd_Ext_Utils;
 
 class Time_Machine extends Scd_Ext_Utils {
+	/**
+	 * Original object for utils.
+	 * @var Scd_Ext_Utils
+	 */
 	private static $utils_original;
+
+	/**
+	 * Instance of this class.
+	 *
+	 * @var self
+	 */
 	private static $instance;
+
+	/**
+	 * Current now time.
+	 *
+	 * @var DateTimeImmutable
+	 */
 	private static $now;
+
+	/**
+	 * Current time zone.
+	 *
+	 * @var DateTimeZone
+	 */
 	private static $timezone;
 
+	/**
+	 * Activate the time machine.
+	 *
+	 * @param bool $reset Reset the date.
+	 */
 	public static function activate( $reset = true ) {
 		if ( ! isset( self::$utils_original ) ) {
 			self::$utils_original = Sensei_Content_Drip()->utils;
@@ -28,25 +55,47 @@ class Time_Machine extends Scd_Ext_Utils {
 		}
 	}
 
+	/**
+	 * Deactivate the time machine.
+	 */
 	public static function deactivate() {
 		if ( isset( self::$utils_original ) ) {
 			Sensei_Content_Drip()->utils = self::$utils_original;
 		}
 	}
 
+	/**
+	 * Reset the time machine to use PHP now and timezone.
+	 */
 	public static function reset() {
 		self::$now      = null;
 		self::$timezone = null;
 	}
 
+	/**
+	 * Set the current time for the time machine.
+	 *
+	 * @param DateTimeImmutable $datetime Date to set.
+	 */
 	public static function set_datetime( DateTimeImmutable $datetime ) {
 		self::$now = $datetime;
 	}
 
+	/**
+	 * Set the current time zone.
+	 *
+	 * @param DateTimeZone $timezone Time zone to set.
+	 */
 	public static function set_timezone( DateTimeZone $timezone ) {
 		self::$timezone = $timezone;
 	}
 
+	/**
+	 * Get the current datetime object.
+	 *
+	 * @return DateTimeImmutable
+	 * @throws \Exception
+	 */
 	public function current_datetime() {
 		if ( isset( self::$now ) ) {
 			return self::$now;
@@ -55,6 +104,11 @@ class Time_Machine extends Scd_Ext_Utils {
 		return new DateTimeImmutable( 'now', $this->wp_timezone() );
 	}
 
+	/**
+	 * Ge the current time zone object.
+	 *
+	 * @return DateTimeZone
+	 */
 	public function wp_timezone() {
 		if ( isset( self::$timezone ) ) {
 			return self::$timezone;
@@ -62,6 +116,4 @@ class Time_Machine extends Scd_Ext_Utils {
 
 		return parent::wp_timezone();
 	}
-
-
 }

--- a/tests/framework/drip-test-helpers.php
+++ b/tests/framework/drip-test-helpers.php
@@ -4,6 +4,12 @@ namespace Scd_Ext\Tests;
 
 use DateTimeImmutable;
 
+/**
+ * Set up a lesson to drop on a specific date.
+ *
+ * @param int               $lesson_id Lesson post ID.
+ * @param DateTimeImmutable $date      Date object to set.
+ */
 function set_absolute_drip_date( $lesson_id, DateTimeImmutable $date ) {
 	$date = $date->setTime( 0, 0, 0 );
 
@@ -17,6 +23,14 @@ function set_absolute_drip_date( $lesson_id, DateTimeImmutable $date ) {
 	}
 }
 
+/**
+ *
+ * Set up a lesson to drop on a relative/dynamic date.
+ *
+ * @param int    $lesson_id Lesson post ID.
+ * @param string $unit      Unit to use (day, month, year).
+ * @param int    $amount    Unit amount.
+ */
 function set_dynamic_drip_date( $lesson_id, $unit, $amount ) {
 	$data = [
 		'_sensei_content_drip_type'                     => 'dynamic',

--- a/tests/framework/drip-test-helpers.php
+++ b/tests/framework/drip-test-helpers.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Scd_Ext\Tests;
+
+use DateTimeImmutable;
+
+function set_absolute_drip_date( $lesson_id, DateTimeImmutable $date ) {
+	$date = $date->setTime( 0, 0, 0 );
+
+	$data =  array(
+		'_sensei_content_drip_type'         => 'absolute',
+		'_sensei_content_drip_details_date' => $date->getTimestamp(),
+	);
+
+	foreach( $data as $key => $value ) {
+		update_post_meta( $lesson_id, $key, $value );
+	}
+}
+
+function set_dynamic_drip_date( $lesson_id, $unit, $amount ) {
+	$data = [
+		'_sensei_content_drip_type'                     => 'dynamic',
+		'_sensei_content_drip_details_date_unit_type'   => $unit,
+		'_sensei_content_drip_details_date_unit_amount' => $amount,
+	];
+
+	foreach( $data as $key => $value ) {
+		update_post_meta( $lesson_id, $key, $value );
+	}
+}

--- a/tests/unit-tests/test-class-scd-ext-access-control.php
+++ b/tests/unit-tests/test-class-scd-ext-access-control.php
@@ -75,10 +75,37 @@ class Scd_Ext_Access_Control_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getting a simple absolute date with +8 timezone shift from UTC.
+	 * Time based test cases.
+	 *
+	 * @return string[][]
 	 */
-	public function testGetLessonDripDateAbsoluteTZShift() {
-		$new_now = new DateTimeImmutable( '2020-01-01 03:44:00', new DateTimeZone( '+0800' ) );
+	public function tzDataProviders() {
+		return [
+			'plus-utc-tz-same' => [
+				'2020-01-01 03:44:00',
+				'+0800',
+			],
+			'plus-utc-tz-cusp' => [
+				'2020-01-01 23:59:59',
+				'+0300',
+			],
+			'minus-utc-tz' => [
+				'2020-01-01 00:00:01',
+				'-1000',
+			],
+		];
+	}
+
+	/**
+	 * Test getting a simple absolute date with timezone shift from UTC.
+	 *
+	 * @dataProvider tzDataProviders
+	 *
+	 * @param string $datetime Datetime string.
+	 * @param string $timezone Timezone.
+	 */
+	public function testGetLessonDripDateAbsoluteTZShift( $datetime, $timezone ) {
+		$new_now = new DateTimeImmutable( $datetime, new DateTimeZone( $timezone ) );
 		Time_Machine::set_datetime( $new_now );
 		Time_Machine::set_timezone( $new_now->getTimezone() );
 
@@ -94,10 +121,15 @@ class Scd_Ext_Access_Control_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getting a simple relative date with +8 timezone shift from UTC.
+	 * Test getting a simple relative date with timezone shift from UTC. Uses the `start` date.
+	 *
+	 * @dataProvider tzDataProviders
+	 *
+	 * @param string $datetime Datetime string.
+	 * @param string $timezone Timezone.
 	 */
-	public function testGetLessonDripDateRelativeTZShift() {
-		$new_now = new DateTimeImmutable( '2020-01-01 15:59:00', new DateTimeZone( '+0800' ) );
+	public function testGetLessonDripDateRelativeTZShiftStartDate( $datetime, $timezone ) {
+		$new_now = new DateTimeImmutable( $datetime, new DateTimeZone( $timezone ) );
 		Time_Machine::set_datetime( $new_now );
 		Time_Machine::set_timezone( $new_now->getTimezone() );
 
@@ -108,6 +140,7 @@ class Scd_Ext_Access_Control_Tests extends WP_UnitTestCase {
 		add_post_meta( $lesson_id, '_lesson_course', $course_id );
 
 		$comment_id = Sensei_Utils::user_start_course( get_current_user_id(), $course_id );
+		// This will use PHP's timezone when outputting the date format.
 		update_comment_meta( $comment_id, 'start', date( 'Y-m-d H:i:s', $new_now->getTimestamp() ) );
 
 		$today = Sensei_Content_Drip()->utils->current_datetime();
@@ -118,5 +151,147 @@ class Scd_Ext_Access_Control_Tests extends WP_UnitTestCase {
 		$drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id, get_current_user_id() );
 
 		$this->assertEquals( $next_week->getTimestamp(), $drip_date->getTimestamp() );
+	}
+
+	/**
+	 * Test getting a simple relative date with timezone shift from UTC. Uses the comment GMT date. This is for
+	 * legacy situations where we weren't setting the `start` meta.
+	 *
+	 * @dataProvider tzDataProviders
+	 *
+	 * @param string $datetime Datetime string.
+	 * @param string $timezone Timezone.
+	 */
+	public function testGetLessonDripDateRelativeTZShiftCommentDate( $datetime, $timezone ) {
+		global $wpdb;
+
+		$new_now = new DateTimeImmutable( $datetime, new DateTimeZone( $timezone ) );
+		Time_Machine::set_datetime( $new_now );
+		Time_Machine::set_timezone( $new_now->getTimezone() );
+
+		$this->login_as_admin();
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create();
+		add_post_meta( $lesson_id, '_lesson_course', $course_id );
+
+		$comment_id = Sensei_Utils::user_start_course( get_current_user_id(), $course_id );
+		delete_comment_meta( $comment_id, 'start' );
+
+		$wpdb->update(
+			$wpdb->comments,
+			[
+				'comment_date'     => $new_now->format( 'Y-m-d H:i:s' ),
+				'comment_date_gmt' => $new_now->setTimezone( new DateTimeZone( 'UTC' ) )->format( 'Y-m-d H:i:s' ),
+			],
+			[
+				'comment_ID' => $comment_id,
+			]
+		);
+
+		// The comment is stored in memory. We need to clear it manually.
+		wp_cache_flush();
+
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+		$next_week = $today->add( new DateInterval( 'P2D' ) )->setTime( 0, 0, 0 );
+
+		set_dynamic_drip_date( $lesson_id, 'day', 2 );
+
+		$drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id, get_current_user_id() );
+
+		$this->assertEquals( $next_week->getTimestamp(), $drip_date->getTimestamp() );
+	}
+
+	/**
+	 * Test `\Scd_Ext_Access_Control::is_dynamic_drip_type_content_blocked` is handling timezones correctly for
+	 * dynamic drips based off of course start date.
+	 *
+	 * @dataProvider tzDataProviders
+	 *
+	 * @param string $datetime Datetime string.
+	 * @param string $timezone Timezone.
+	 */
+	public function testIsDynamicDripTypeContentBlockedTZShiftStartDate( $datetime, $timezone ) {
+		$new_now = new DateTimeImmutable( $datetime, new DateTimeZone( $timezone ) );
+		Time_Machine::set_datetime( $new_now );
+		Time_Machine::set_timezone( $new_now->getTimezone() );
+
+		$this->login_as_admin();
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create();
+		add_post_meta( $lesson_id, '_lesson_course', $course_id );
+
+		$comment_id = Sensei_Utils::user_start_course( get_current_user_id(), $course_id );
+		// This will use PHP's timezone when outputting the date format.
+		update_comment_meta( $comment_id, 'start', date( 'Y-m-d H:i:s', $new_now->getTimestamp() ) );
+
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+
+		set_dynamic_drip_date( $lesson_id, 'day', 2 );
+
+		// On the same day, they should not have access.
+		$this->assertTrue( Sensei_Content_Drip()->access_control->is_dynamic_drip_type_content_blocked( $lesson_id ), 'Access should be blocked on the day the user starts the course' );
+
+		// Go to the next day.
+		$tomorrow = $today->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertTrue( Sensei_Content_Drip()->access_control->is_dynamic_drip_type_content_blocked( $lesson_id ), 'Access should be blocked on the day after the user starts the course' );
+
+		// Go to the next day.
+		$tomorrow = $tomorrow->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertFalse( Sensei_Content_Drip()->access_control->is_dynamic_drip_type_content_blocked( $lesson_id ), 'Access should NOT be blocked on two days after the user starts the course' );
+
+		// Go to the next day to make sure it still isn't blocked.
+		$tomorrow = $tomorrow->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertFalse( Sensei_Content_Drip()->access_control->is_dynamic_drip_type_content_blocked( $lesson_id ), 'Access should NOT be blocked on three days after the user starts the course' );
+	}
+
+	/**
+	 * Test `\Scd_Ext_Access_Control::is_absolute_drip_type_content_blocked` is handling timezones correctly for
+	 * absolute drips.
+	 *
+	 * @dataProvider tzDataProviders
+	 *
+	 * @param string $datetime Datetime string.
+	 * @param string $timezone Timezone.
+	 */
+	public function testIsAbsoluteDripTypeContentBlockedTZShift( $datetime, $timezone ) {
+		$new_now = new DateTimeImmutable( $datetime, new DateTimeZone( $timezone ) );
+		Time_Machine::set_datetime( $new_now );
+		Time_Machine::set_timezone( $new_now->getTimezone() );
+
+		$this->login_as_admin();
+
+		$lesson_id = $this->factory->lesson->create();
+
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+
+		set_absolute_drip_date( $lesson_id, $new_now->add( new DateInterval( 'P3D' ) ) );
+
+		// On the same day, they should not have access.
+		$this->assertTrue( Sensei_Content_Drip()->access_control->is_absolute_drip_type_content_blocked( $lesson_id ), 'Access should be blocked on current+1' );
+
+		// Go to the next day.
+		$tomorrow = $today->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertTrue( Sensei_Content_Drip()->access_control->is_absolute_drip_type_content_blocked( $lesson_id ), 'Access should be blocked on current+2' );
+
+		// Go to the next day.
+		$tomorrow = $tomorrow->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertTrue( Sensei_Content_Drip()->access_control->is_absolute_drip_type_content_blocked( $lesson_id ), 'Access should be blocked on current+3' );
+
+		// Go to the next day.
+		$tomorrow = $tomorrow->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertFalse( Sensei_Content_Drip()->access_control->is_absolute_drip_type_content_blocked( $lesson_id ), 'Access should NOT be blocked on current+4' );
+
+		// Go to the next day to make sure it still isn't blocked.
+		$tomorrow = $tomorrow->add( new DateInterval( 'P1D' ) );
+		Time_Machine::set_datetime( $tomorrow );
+		$this->assertFalse( Sensei_Content_Drip()->access_control->is_absolute_drip_type_content_blocked( $lesson_id ), 'Access should NOT be blocked on current+5' );
 	}
 }

--- a/tests/unit-tests/test-class-scd-ext-access-control.php
+++ b/tests/unit-tests/test-class-scd-ext-access-control.php
@@ -1,0 +1,122 @@
+<?php
+
+use Scd_Ext\Tests\Time_Machine;
+use function Scd_Ext\Tests\set_absolute_drip_date;
+use function Scd_Ext\Tests\set_dynamic_drip_date;
+
+
+/**
+ * Testing the Sensei Content Drip Access Control class.
+ *
+ * @class Scd_Ext_Access_Control
+ */
+class Scd_Ext_Access_Control_Tests extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Sensei post factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp() {
+		$this->factory = new Sensei_Factory();
+		$this->originalUtils = Sensei_Content_Drip()->utils;
+
+		Time_Machine::activate( true );
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown() {
+		Time_Machine::deactivate();
+	}
+
+	/**
+	 * Test getting a simple absolute date.
+	 */
+	public function testGetLessonDripDateAbsolute() {
+		$lesson_id = $this->factory->lesson->create();
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+		$last_week = $today->sub( new DateInterval( 'P7D' ) )->setTime( 0, 0, 0 );
+
+		set_absolute_drip_date( $lesson_id, $last_week );
+
+		$drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id );
+
+		$this->assertEquals( $last_week->getTimestamp(), $drip_date->getTimestamp() );
+	}
+
+	/**
+	 * Test getting a relative absolute date.
+	 */
+	public function testGetLessonDripDateRelative() {
+		$this->login_as_admin();
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create();
+		add_post_meta( $lesson_id, '_lesson_course', $course_id );
+
+		Sensei_Utils::user_start_course( get_current_user_id(), $course_id );
+
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+		$next_week = $today->add( new DateInterval( 'P5D' ) )->setTime( 0, 0, 0 );
+
+		set_dynamic_drip_date( $lesson_id, 'day', 5 );
+
+		$drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id, get_current_user_id() );
+
+		$this->assertEquals( $next_week->getTimestamp(), $drip_date->getTimestamp() );
+	}
+
+	/**
+	 * Test getting a simple absolute date with +8 timezone shift from UTC.
+	 */
+	public function testGetLessonDripDateAbsoluteTZShift() {
+		$new_now = new DateTimeImmutable( '2020-01-01 03:44:00', new DateTimeZone( '+0800' ) );
+		Time_Machine::set_datetime( $new_now );
+		Time_Machine::set_timezone( $new_now->getTimezone() );
+
+		$lesson_id = $this->factory->lesson->create();
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+		$last_week = $today->sub( new DateInterval( 'P7D' ) )->setTime( 0, 0, 0 );
+
+		set_absolute_drip_date( $lesson_id, $last_week );
+
+		$drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id );
+
+		$this->assertEquals( $last_week->getTimestamp(), $drip_date->getTimestamp() );
+	}
+
+	/**
+	 * Test getting a simple relative date with +8 timezone shift from UTC.
+	 */
+	public function testGetLessonDripDateRelativeTZShift() {
+		$new_now = new DateTimeImmutable( '2020-01-01 15:59:00', new DateTimeZone( '+0800' ) );
+		Time_Machine::set_datetime( $new_now );
+		Time_Machine::set_timezone( $new_now->getTimezone() );
+
+		$this->login_as_admin();
+
+		$course_id = $this->factory->course->create();
+		$lesson_id = $this->factory->lesson->create();
+		add_post_meta( $lesson_id, '_lesson_course', $course_id );
+
+		$comment_id = Sensei_Utils::user_start_course( get_current_user_id(), $course_id );
+		update_comment_meta( $comment_id, 'start', date( 'Y-m-d H:i:s', $new_now->getTimestamp() ) );
+
+		$today = Sensei_Content_Drip()->utils->current_datetime();
+		$next_week = $today->add( new DateInterval( 'P5D' ) )->setTime( 0, 0, 0 );
+
+		set_dynamic_drip_date( $lesson_id, 'day', 5 );
+
+		$drip_date = Sensei_Content_Drip()->access_control->get_lesson_drip_date( $lesson_id, get_current_user_id() );
+
+		$this->assertEquals( $next_week->getTimestamp(), $drip_date->getTimestamp() );
+	}
+}

--- a/tests/unit-tests/test-class-scd-ext-drip-email.php
+++ b/tests/unit-tests/test-class-scd-ext-drip-email.php
@@ -1,12 +1,13 @@
 <?php
 /**
  * Testing the Sensei Content Drip ( scd ) Email functionality class
- * @class Scd_Ext_Lesson_Admin
+ *
+ * @class Scd_Ext_Drip_Email
  * @file ../includes/class-scd-ext-lesson-admin.php
  */
-class DripEmailTest extends WP_UnitTestCase {
+class Scd_Ext_Drip_Email_Tests extends WP_UnitTestCase {
 	public function testClassSetup() {
-		$this->assertTrue( class_exists( 'Scd_Ext_drip_email' ), 'The plugin class file was not loaded' );
+		$this->assertTrue( class_exists( 'Scd_Ext_Drip_Email' ), 'The plugin class file was not loaded' );
 		$this->assertTrue( isset( Sensei_Content_Drip()->drip_email ), 'The plugin class was not intstantiated' );
 	}
 

--- a/tests/unit-tests/test-class-scd-ext-lesson-admin.php
+++ b/tests/unit-tests/test-class-scd-ext-lesson-admin.php
@@ -1,10 +1,12 @@
 <?php
 /**
-* Testing the Sensei Content Drip ( scd ) Email functionality class
-* @class Scd_Ext_lesson_admin
-* @file ../includes/class-scd-ext-drip-email.php
-*/
-class LessonAdminTest extends WP_UnitTestCase {
+ * Testing the Sensei Content Drip ( scd ) Email functionality class
+ *
+ * @class Scd_Ext_Lesson_Admin
+ * @file ../../includes/class-scd-ext-drip-email.php
+ */
+
+class Scd_Ext_Lesson_Admin_Tests extends WP_UnitTestCase {
 	function testClass() {
 		$this->assertTrue( class_exists( 'Scd_Ext_Lesson_Admin' ), 'The plugin class file was not loaded' );
 		$this->assertTrue( isset( Sensei_Content_Drip()->lesson_admin ), 'The plugin class was not intstantiated' );

--- a/tests/unit-tests/test-class-scd-ext-utils.php
+++ b/tests/unit-tests/test-class-scd-ext-utils.php
@@ -1,10 +1,11 @@
 <?php
 /**
-* Testing the Sensei Content Drip ( scd ) Email functionality class
-* @class Scd_Ext_Utils
-* @file ../includes/class-scd-ext-drip-email.php
+ * Testing the Sensei Content Drip ( scd ) utilities class.
+ *
+ * @class Scd_Ext_Utils
+ * @file ../../includes/class-scd-ext-utils.php
 */
-class LessonUtilitiesTest extends WP_UnitTestCase {
+class Scd_Ext_Utils_Tests extends WP_UnitTestCase {
 	function testClass() {
 		$this->assertTrue( class_exists( 'Scd_Ext_Utils' ), 'The plugin class file was not loaded' );
 		$this->assertTrue( isset( Sensei_Content_Drip()->utils ), 'The plugin class was not intstantiated' );


### PR DESCRIPTION
Fixes #196

### Changes proposed in this Pull Request

* Bumps WP minimum version to 5.3. This is in line with Sensei LMS and also saves lots of annoying compatibility checks for WP 5.3's new date functions.
* Standardize all date time usage so that content will drip using WordPress' timezone. 
* Reorganizes tests to conform with Sensei test structure.

### Testing instructions

* Using various timezones relative to UTC/PHP timezone, check to make sure both relative/dynamic drips and absolute drips happen at the correct date.