### PR TITLE
Release 2.1.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Sensei Content Drip Changelog ***
 
-2020.12.02 - version 2.1.0
+2020.12.03 - version 2.1.0
 * New: Adds partial French translations - #213
 * Tweak: Use WordPress' timezone when dripping lessons - #214
 * Fix: Minor display issue in WordPress admin on the lesson editor - #201

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Sensei Content Drip Changelog ***
 
+2020.12.02 - version 2.1.0
+* New: Adds partial French translations - #213
+* Tweak: Use WordPress' timezone when dripping lessons - #214
+* Fix: Minor display issue in WordPress admin on the lesson editor - #201
+
 2020.03.26 - version 2.0.2
 * Tweak: Switch to new methods to check enrolment when possible - #193, #192
 * Fix: Bug causing admin users to be unable to view courses - #187

--- a/lang/sensei-content-drip.pot
+++ b/lang/sensei-content-drip.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Sensei Content Drip plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sensei Content Drip 2.0.2\n"
+"Project-Id-Version: Sensei Content Drip 2.1.0\n"
 "Report-Msgid-Bugs-To: https://woocommerce.com/support\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-08-26T16:42:40+00:00\n"
+"POT-Creation-Date: 2020-12-02T14:13:05+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.4.0\n"
 "X-Domain: sensei-content-drip\n"
@@ -36,21 +36,26 @@ msgid "https://automattic.com/"
 msgstr ""
 
 #. translators: %1$s is version of PHP that SCD requires; %2$s is the version of PHP WordPress is running on.
-#: includes/class-scd-ext-dependency-checker.php:91
+#: includes/class-scd-ext-dependency-checker.php:111
 msgid "<strong>Sensei Content Drip</strong> requires a minimum PHP version of %1$s, but you are running %2$s."
 msgstr ""
 
-#: includes/class-scd-ext-dependency-checker.php:101
+#: includes/class-scd-ext-dependency-checker.php:121
 msgid "Learn more about updating PHP"
 msgstr ""
 
 #. translators: accessibility text
-#: includes/class-scd-ext-dependency-checker.php:103
+#: includes/class-scd-ext-dependency-checker.php:123
 msgid "(opens in a new tab)"
 msgstr ""
 
+#. translators: %1$s is version of WordPress that SCD requires; %2$s is the current version of WordPress installed.
+#: includes/class-scd-ext-dependency-checker.php:144
+msgid "<strong>Sensei Content Drip</strong> requires a minimum WordPress version of %1$s, but you are running %2$s."
+msgstr ""
+
 #. translators: %1$s is the minimum version number of Sensei that is required.
-#: includes/class-scd-ext-dependency-checker.php:122
+#: includes/class-scd-ext-dependency-checker.php:164
 msgid "<strong>Sensei Content Drip</strong> requires that the plugin <strong>Sensei</strong> (minimum version: <strong>%1$s</strong>) is installed and activated."
 msgstr ""
 
@@ -71,85 +76,91 @@ msgctxt "column name"
 msgid "Drip Schedule"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:138
+#: includes/class-scd-ext-lesson-admin.php:140
 msgid "Immediately"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:141
+#. translators: %s is replaced with the date on which the lesson becomes available
+#: includes/class-scd-ext-lesson-admin.php:144
 msgid "On %s"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:155
+#. translators: %s is replaced with the interval after which the lesson becomes available (e.g. 2 days)
+#: includes/class-scd-ext-lesson-admin.php:158
 msgid "After %s"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:187
+#: includes/class-scd-ext-lesson-admin.php:190
 msgid "In order to use the content drip settings, please select a course for this lesson."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:218
+#: includes/class-scd-ext-lesson-admin.php:221
 msgid "When should this lesson become available?"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:220
+#: includes/class-scd-ext-lesson-admin.php:223
 msgid "As soon as the course is started"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:221
+#: includes/class-scd-ext-lesson-admin.php:224
 msgid "On a specific date"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:226
+#: includes/class-scd-ext-lesson-admin.php:229
 msgid "A specific interval after the course start date"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:230
+#. translators: %s is replaced with Y-m-d
+#: includes/class-scd-ext-lesson-admin.php:234
 msgid "Select the date on which this lesson should become available (accepted date format is %s)"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:237
+#: includes/class-scd-ext-lesson-admin.php:240
 msgid "Please select a course for this lesson in order to use this drip type."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:244
+#: includes/class-scd-ext-lesson-admin.php:247
 msgid "Day(s)"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:245
+#: includes/class-scd-ext-lesson-admin.php:248
 msgid "Week(s)"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:246
+#: includes/class-scd-ext-lesson-admin.php:249
 msgid "Month(s)"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:251
+#. translators: %s is replaced with the current user's email address
+#: includes/class-scd-ext-lesson-admin.php:257
 msgid "Send Test Email to %s"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:330
+#: includes/class-scd-ext-lesson-admin.php:338
 msgid "Please choose a date under the  \"Absolute\" select box."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:351
+#. translators: %s is replaced with Y-m-d
+#: includes/class-scd-ext-lesson-admin.php:360
 msgid "The date format you selected cannot be parsed (we expect dates to be formatted like \"%s\")"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:373
+#: includes/class-scd-ext-lesson-admin.php:383
 msgid "Please select the correct units for your chosen option \"After previous lesson\" ."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:376
-msgid "Please enter a numberic unit number for your chosen option \"After previous lesson\" ."
+#: includes/class-scd-ext-lesson-admin.php:386
+msgid "Please enter a unit number for your chosen option \"After previous lesson\" ."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:425
+#: includes/class-scd-ext-lesson-admin.php:435
 msgid "The content drip type was reset to \"none\"."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:427
+#. translators: %1$s is replaced with the notice type and %2$s is replaced with the message
+#: includes/class-scd-ext-lesson-admin.php:438
 msgctxt "type and message"
-msgid "Sensei Content Drip %s: %s"
+msgid "Sensei Content Drip %1$s: %2$s"
 msgstr ""
 
 #: includes/class-scd-ext-manual-drip.php:99
@@ -186,11 +197,13 @@ msgstr ""
 msgid "Content Drip"
 msgstr ""
 
-#: includes/class-scd-ext-manual-drip.php:417
+#. translators: %d is replaced with the invalid user ID
+#: includes/class-scd-ext-manual-drip.php:418
 msgid "The userID( %d ) is invalid, there is no user that matches this ID "
 msgstr ""
 
-#: includes/class-scd-ext-manual-drip.php:432
+#. translators: %d is replaced with the invalid lesson ID
+#: includes/class-scd-ext-manual-drip.php:434
 msgid "The lessonId( %d ) is invalid, there is no lesson that matches this ID "
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-content-drip",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-content-drip",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Sensei Content Drip",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -1,7 +1,7 @@
 <?php
 /*
  * Plugin Name: Sensei Content Drip
- * Version: 2.0.2
+ * Version: 2.1.0
  * Plugin URI: https://woocommerce.com/products/sensei-content-drip/
  * Description:  Control access to Sensei lessons by scheduling them to become available after a determined time.
  * Author: Automattic
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SENSEI_CONTENT_DRIP_VERSION', '2.0.2' );
+define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.0' );
 define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
 define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 


### PR DESCRIPTION
Pre-built package: 
[sensei-content-drip.zip](https://github.com/woocommerce/sensei-content-drip/files/5629806/sensei-content-drip.zip)

This also includes our new build system, so we might want to just to a quick test for visual regressions.

* New: Adds partial French translations - #213
* Tweak: Use WordPress' timezone when dripping lessons - #214
* Fix: Minor display issue in WordPress admin on the lesson editor - #201