### PR TITLE
Fix admin manual drip script enqueue

### DIFF
--- a/includes/class-sensei-content-drip.php
+++ b/includes/class-sensei-content-drip.php
@@ -184,7 +184,7 @@ class Sensei_Content_Drip {
 		}
 
 		// Load the learner management functionality script
-		if ( 'sensei_page_sensei_learners' === $hook &&  isset( $_GET['course_id'] ) && isset( $_GET['view'] ) && 'learners' === $_GET['view'] ) {
+		if ( 'sensei-lms_page_sensei_learners' === $hook &&  isset( $_GET['course_id'] ) && isset( $_GET['view'] ) && 'learners' === $_GET['view'] ) {
 			wp_register_script( $this->_token . '-admin-manual-drip-script', esc_url( $this->assets_url ) . 'js/admin-manual-drip.js', array( 'underscore','jquery', 'backbone' ), $this->_version, true );
 			wp_enqueue_script( $this->_token . '-admin-manual-drip-script' );
 		}


### PR DESCRIPTION
Fixes issue reported in https://github.com/woocommerce/sensei-content-drip/issues/222#issuecomment-916726977

### Changes proposed in this Pull Request

* The script enqueue check was broken in the past through this change in the core plugin: https://github.com/Automattic/sensei/commit/325481069b8e977f450bd5673a7c5d993d83346f. This just tweaks the `$hook` check making it work again.

### Testing instructions

* Create a course with a lesson.
* Set a content drip to the lesson.
* Enroll a user in the course.
* Go to wp-admin > Learner Management > Manage learners (in the course created)
* In the Manual Content Drip section, select the user and the lesson.
* Give access to the user.
* Select the user and the lesson again.
* Make sure now you see a button to remove the access.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="495" alt="Screen Shot 2021-09-10 at 20 02 03" src="https://user-images.githubusercontent.com/876340/132926135-bae9715d-4ac1-416c-b1a6-021ae64e6ff0.png">
