### PR TITLE
Fix/manual content drip no lesson

### DIFF
--- a/includes/class-scd-ext-lesson-admin.php
+++ b/includes/class-scd-ext-lesson-admin.php
@@ -271,26 +271,7 @@ class Scd_Ext_Lesson_Admin {
 	 * @return array WP_Post
 	 */
 	public function get_course_lessons( $course_id = 0, $exclude = array() ) {
-		$args = array(
-			'post_type'          => 'lesson',
-			'numberposts'        => -1,
-			'meta_key'           => '_order_' . absint( $course_id ),
-			'orderby'            => 'meta_value_num date',
-			'order'              => 'ASC',
-			'exclude'            => (array) $exclude,
-			'meta_query'         => array(
-				array(
-					'key'   => '_lesson_course',
-					'value' => absint( $course_id ),
-				),
-			),
-			'post_status'        => 'public',
-			'suppress_filters'   => 0
-		);
-
-		$lessons = get_posts( $args );
-
-		return $lessons;
+		return Sensei()->course->course_lessons( $course_id, 'public', 'all', [ 'exclude' => $exclude ] );
 	}
 
 	/**

--- a/includes/class-scd-ext-manual-drip.php
+++ b/includes/class-scd-ext-manual-drip.php
@@ -96,7 +96,7 @@ class Scd_Ext_Manual_Drip {
 		$course_lessons = Sensei_Content_Drip()->lesson_admin->get_course_lessons( $course_id );
 		?>
 		<div class="postbox scd-learner-managment manual-content-drip">
-				<h3><span><?php esc_html_e( 'Manual Content Drip', 'sensei-content-drip' ); ?></span></h3>
+				<h2 class="postbox-title"><span><?php esc_html_e( 'Manual Content Drip', 'sensei-content-drip' ); ?></span></h2>
 				<div class="inside">
 					<form name="scd_manual_drip_learners_lesson" action="" method="post">
 						<p>


### PR DESCRIPTION
Fixes #217 

### Changes proposed in this Pull Request

- Use `Sensei()->course->course_lessons()` method for fetching lessons for Manual Content Drip instead of fetching the lessons manually via `get_posts()`.

### Testing instructions

- Create a course with modules and lessons in them.
- Go to Learner Management and click on the course.
- Confirm that the "Manual Content Drip" section lists all the lessons of the course in "Select a Lesson" select field.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* n/a

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* n/a

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Course and it's lessons

<img width="628" alt="Screen Shot 2021-10-15 at 1 21 38 PM" src="https://user-images.githubusercontent.com/2578542/137464545-1b665a70-f458-4fda-8bfb-cdeb8311909f.png">

#### Before

<img width="822" alt="Screen Shot 2021-10-15 at 1 23 14 PM" src="https://user-images.githubusercontent.com/2578542/137464750-b1aa84a1-ed16-49fa-9f2f-44a37f6f062d.png">

#### After

<img width="822" alt="Screen Shot 2021-10-15 at 1 23 51 PM" src="https://user-images.githubusercontent.com/2578542/137464855-2d3d18df-cb26-4c3b-914d-0da5df2740f5.png">


