### PR TITLE
Release 2.1.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Sensei Content Drip Changelog ***
 
+2021.10.19 - version 2.1.1
+Fix: Can't remove the lesson access from user if already has one - #227
+Fix: Lessons that are in a module are not available in Manual Content Drip meta box - #217
+
 2020.12.03 - version 2.1.0
 * New: Adds partial French translations - #213
 * Tweak: Use WordPress' timezone when dripping lessons - #214

--- a/lang/sensei-content-drip.pot
+++ b/lang/sensei-content-drip.pot
@@ -1,17 +1,17 @@
-# Copyright (C) 2020 Automattic
+# Copyright (C) 2021 Automattic
 # This file is distributed under the same license as the Sensei Content Drip plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Sensei Content Drip 2.1.0\n"
+"Project-Id-Version: Sensei Content Drip 2.1.1\n"
 "Report-Msgid-Bugs-To: https://woocommerce.com/support\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-12-02T14:13:05+00:00\n"
+"POT-Creation-Date: 2021-10-19T12:28:56+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: sensei-content-drip\n"
 
 #. Plugin Name of the plugin
@@ -136,29 +136,29 @@ msgstr ""
 msgid "Send Test Email to %s"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:338
+#: includes/class-scd-ext-lesson-admin.php:319
 msgid "Please choose a date under the  \"Absolute\" select box."
 msgstr ""
 
 #. translators: %s is replaced with Y-m-d
-#: includes/class-scd-ext-lesson-admin.php:360
+#: includes/class-scd-ext-lesson-admin.php:341
 msgid "The date format you selected cannot be parsed (we expect dates to be formatted like \"%s\")"
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:383
+#: includes/class-scd-ext-lesson-admin.php:364
 msgid "Please select the correct units for your chosen option \"After previous lesson\" ."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:386
+#: includes/class-scd-ext-lesson-admin.php:367
 msgid "Please enter a unit number for your chosen option \"After previous lesson\" ."
 msgstr ""
 
-#: includes/class-scd-ext-lesson-admin.php:435
+#: includes/class-scd-ext-lesson-admin.php:416
 msgid "The content drip type was reset to \"none\"."
 msgstr ""
 
 #. translators: %1$s is replaced with the notice type and %2$s is replaced with the message
-#: includes/class-scd-ext-lesson-admin.php:438
+#: includes/class-scd-ext-lesson-admin.php:419
 msgctxt "type and message"
 msgid "Sensei Content Drip %1$s: %2$s"
 msgstr ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-content-drip",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2649,14 +2649,6 @@
         "webpack-cli": "^3.3.11",
         "webpack-livereload-plugin": "^2.3.0",
         "webpack-sources": "^2.2.0"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "npm:wp-prettier@2.2.1-beta-1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-          "dev": true
-        }
       }
     },
     "@wordpress/stylelint-config": {
@@ -3352,6 +3344,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bl": {
       "version": "4.0.3",
@@ -6304,6 +6306,13 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "filename-reserved-regex": {
       "version": "2.0.0",
@@ -9810,6 +9819,13 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.23",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
@@ -11029,6 +11045,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.2.1-beta-1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -14826,7 +14848,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-content-drip",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Sensei Content Drip",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -1,13 +1,13 @@
 <?php
 /*
  * Plugin Name: Sensei Content Drip
- * Version: 2.1.0
+ * Version: 2.1.1
  * Plugin URI: https://woocommerce.com/products/sensei-content-drip/
  * Description:  Control access to Sensei lessons by scheduling them to become available after a determined time.
  * Author: Automattic
  * Author URI: https://automattic.com/
- * Requires at least: 5.3
- * Tested up to: 5.6
+ * Requires at least: 5.6
+ * Tested up to: 5.8
  * Requires PHP: 7.0
  * Domain path: /lang/
  * Woo: 543363:8ee2cdf89f55727f57733133ccbbfbb0
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.0' );
+define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.1' );
 define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
 define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 


### PR DESCRIPTION
Release #[2.1.1](https://github.com/woocommerce/sensei-content-drip/milestone/12?closed=1)

### Changes proposed in this Pull Request

* Fix: Can't remove the lesson access from user if already has one - #227 
* Fix: Lessons that are in a module are not available in Manual Content Drip meta box - #21
