### PR TITLE
add a check to see if plugin is already active with Sensei Pro

### DIFF
--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -44,7 +44,7 @@ class Scd_Ext_Dependency_Checker {
 	 * @return bool
 	 */
 	public static function is_sensei_pro_active() {
-		if  ( defined( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE' ) ) {
+		if  ( defined( 'SENSEI_PRO_VERSION' ) ) {
 			return true;
 		}
 		return false;

--- a/includes/class-scd-ext-dependency-checker.php
+++ b/includes/class-scd-ext-dependency-checker.php
@@ -39,6 +39,18 @@ class Scd_Ext_Dependency_Checker {
 	}
 
 	/**
+	 * Checks if plugin already active through Sensei Pro.
+	 *
+	 * @return bool
+	 */
+	public static function is_sensei_pro_active() {
+		if  ( defined( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE' ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Checks if all plugin dependencies are met.
 	 *
 	 * @return bool

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -21,19 +21,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.1' );
-define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
-define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
-
-require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
-
-if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
-	return;
+function sensei_content_drip_requirements_met() {
+	if ( defined( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE' ) ) {
+		return false;
+	}
+	return true;
 }
 
-require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
+if ( sensei_content_drip_requirements_met() ) {
+	define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.1' );
+	define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
+	define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
-// Load the plugin after all the other plugins have loaded.
-add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
+	require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
-Sensei_Content_Drip::instance();
+	if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
+		return;
+	}
+
+	require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
+
+	// Load the plugin after all the other plugins have loaded.
+	add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
+
+	Sensei_Content_Drip::instance();
+}

--- a/sensei-content-drip.php
+++ b/sensei-content-drip.php
@@ -20,29 +20,23 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
 
-function sensei_content_drip_requirements_met() {
-	if ( defined( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE' ) ) {
-		return false;
-	}
-	return true;
+if ( Scd_Ext_Dependency_Checker::is_sensei_pro_active() ) {
+	return;
 }
 
-if ( sensei_content_drip_requirements_met() ) {
-	define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.1' );
-	define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
-	define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+define( 'SENSEI_CONTENT_DRIP_VERSION', '2.1.1' );
+define( 'SENSEI_CONTENT_DRIP_PLUGIN_FILE', __FILE__ );
+define( 'SENSEI_CONTENT_DRIP_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
 
-	require_once dirname( __FILE__ ) . '/includes/class-scd-ext-dependency-checker.php';
-
-	if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
-		return;
-	}
-
-	require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
-
-	// Load the plugin after all the other plugins have loaded.
-	add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
-
-	Sensei_Content_Drip::instance();
+if ( ! Scd_Ext_Dependency_Checker::are_system_dependencies_met() ) {
+	return;
 }
+
+require_once dirname( __FILE__ ) . '/includes/class-sensei-content-drip.php';
+
+// Load the plugin after all the other plugins have loaded.
+add_action( 'plugins_loaded', array( 'Sensei_Content_Drip', 'init' ), 5 ) ;
+
+Sensei_Content_Drip::instance();


### PR DESCRIPTION
Currently, if you have Sensei Pro active and you go activate Content Drip, you'll get a Fatal Error becuase you're redeclaring the same constants.

### Changes proposed in this Pull Request

* Add a check before the plugin runs to check if it's already active through Sensei Pro

### Testing instructions

* Activate Sensei Pro
* Activate Sensei Content Drip
* You'll see a banner letting you know you have a legacy plugin
* You won't see any Fatal Errors now!

### Screenshot / Video
<img width="955" alt="Screen Shot 2022-09-04 at 4 16 07 PM" src="https://user-images.githubusercontent.com/3220162/188337207-ffcb4b44-6d44-4914-86fc-875b93113b9f.png">

